### PR TITLE
Add missing include_paths.php to phar compiler script.

### DIFF
--- a/src/Psy/Compiler.php
+++ b/src/Psy/Compiler.php
@@ -62,6 +62,7 @@ class Compiler
         }
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/include_paths.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_real.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_namespaces.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_classmap.php'));


### PR DESCRIPTION
The phar file being produced by bin/compile (and hosted on psysh.org) is missing a required file:

> PHP Fatal error:  require(): Failed opening required 'phar:///home/josh/tmp/psysh/bin/psysh.phar/vendor/composer/include_paths.php' (include_path='.:/usr/share/php:/usr/share/pear') in phar:///home/josh/tmp/psysh/bin/psysh.phar/vendor/composer/autoload_real.php on line 29

Added missing file to src/Psy/Compiler.php
