### PR TITLE
Fix autoloader path in psysh binary

### DIFF
--- a/bin/psysh
+++ b/bin/psysh
@@ -12,8 +12,8 @@
 
 if (is_file(__DIR__ . '/../vendor/autoload.php')) {
     require(__DIR__ . '/../vendor/autoload.php');
-} elseif (is_file(__DIR__ . '/../../../../vendor/autoload.php')) {
-    require(__DIR__ . '/../../../../vendor/autoload.php');
+} elseif (is_file(__DIR__ . '/../../../autoload.php')) {
+    require(__DIR__ . '/../../../autoload.php');
 } else {
     die(
         'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL .


### PR DESCRIPTION
When vendored in a project with a custom vendor directory (`vendor-dir` configuration option in `composer.json`), psysh binary fails to include the Composer autoloader.
This PR addresses this issue by making the autoloader include path for first-party projects relative to the project vendor directory.
