### PR TITLE
5.4 - set_error_handler to restore_error_handler

### DIFF
--- a/src/Psy/Presenter/ObjectPresenter.php
+++ b/src/Psy/Presenter/ObjectPresenter.php
@@ -103,7 +103,7 @@ class ObjectPresenter extends RecursivePresenter
     protected function getProperties($value, \ReflectionClass $class)
     {
         $deprecated = false;
-        $oldHandler = set_error_handler(function($errno, $errstr) use (&$deprecated) {
+        set_error_handler(function($errno, $errstr) use (&$deprecated) {
             if (in_array($errno, array(E_DEPRECATED, E_USER_DEPRECATED))) {
                 $deprecated = true;
             } else {


### PR DESCRIPTION
set_error_handler(null) is >= 5.5

restore_error_handler() is 5.4 compatible and pops the most recent error handler off the stack, which appears to serve the same intended effect
