### PR TITLE
[wip] Autocomplete for variable scope only.

### DIFF
--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -234,9 +234,9 @@ class Shell extends Application
 
         $this->readline->readHistory();
 
-        // if ($this->config->useReadline()) {
-        //     readline_completion_function(array($this, 'autocomplete'));
-        // }
+        if ($this->config->useReadline()) {
+            readline_completion_function(array($this, 'autocomplete'));
+        }
 
         $this->output->writeln($this->getHeader());
 
@@ -778,17 +778,13 @@ class Shell extends Application
      *
      * @return mixed Array possible completions for the given input, if any.
      */
-    protected function autocomplete($text)
+    public function autocomplete($text)
     {
         $info = readline_info();
-        // $line = substr($info['line_buffer'], 0, $info['end']);
 
-        // Check whether there's a command for this
-        // $words = explode(' ', $line);
-        // $firstWord = reset($words);
+        // Finds the character preceeding the submitted $text
+        $firstChar = $info['line_buffer'][$info['point']-strlen($text)-1];
 
-        // check whether this is a variable...
-        $firstChar = substr($info['line_buffer'], max(0, $info['end'] - strlen($text) - 1), 1);
         if ($firstChar == '$') {
             return $this->getScopeVariableNames();
         }


### PR DESCRIPTION
This seems to work, but comments are certainly welcome. I am trying to write some tests, but given the nature of the feature (queuing off [TAB] and whatever is on the current buffer) it's proving difficult. Do you have suggestions?

This also seems like it could be extended a bit to start looking at class constants, application defined functions and so on. But I couldn't, just yet, figure out just how to invoke those methods and get back arrays rather than pretty print.

This also has an annoying side effect of appending a space at the end of the autocomplete.