### PR TITLE
Stop ever increasing table size when help is used

### DIFF
--- a/src/Psy/Command/HelpCommand.php
+++ b/src/Psy/Command/HelpCommand.php
@@ -67,6 +67,7 @@ class HelpCommand extends Command
             $commands = $this->getApplication()->all();
 
             $table = $this->getApplication()->getHelperSet()->get('table')
+                ->setRows(array())
                 ->setLayout(TableHelper::LAYOUT_BORDERLESS)
                 ->setHorizontalBorderChar('')
                 ->setCrossingChar('');


### PR DESCRIPTION
The `help` command displays a tabular overview over all commands. It does so by using a console helper which is reused between invocations of the help command.

This leads to the commands table to be ever growing.

This PR contains one commit that fixes the issue.

This is the new version of #91, but now rebased on top of `develop` and with PHP 5.3 compatibility.
