### PR TITLE
Implemented --all option to dump command

### DIFF
--- a/src/Psy/Command/DumpCommand.php
+++ b/src/Psy/Command/DumpCommand.php
@@ -12,6 +12,7 @@
 namespace Psy\Command;
 
 use Psy\Exception\RuntimeException;
+use Psy\Presenter\Presenter;
 use Psy\Presenter\PresenterManager;
 use Psy\Presenter\PresenterManagerAware;
 use Symfony\Component\Console\Input\InputArgument;
@@ -48,6 +49,7 @@ class DumpCommand extends ReflectingCommand implements PresenterManagerAware
             ->setDefinition(array(
                 new InputArgument('target', InputArgument::REQUIRED, 'A target object or primitive to dump.', null),
                 new InputOption('depth', '', InputOption::VALUE_REQUIRED, 'Depth to parse', 10),
+                new InputOption('all', 'a', InputOption::VALUE_NONE, 'Include private and protected methods and properties.')
             ))
             ->setDescription('Dump an object or primitive.')
             ->setHelp(<<<HELP
@@ -69,7 +71,7 @@ HELP
     {
         $depth  = $input->getOption('depth');
         $target = $this->resolveTarget($input->getArgument('target'));
-        $output->page($this->presenterManager->present($target, $depth, true));
+        $output->page($this->presenterManager->present($target, $depth, true, $input->getOption('all') ? Presenter::VERBOSE : null));
     }
 
     /**

--- a/src/Psy/Presenter/ArrayPresenter.php
+++ b/src/Psy/Presenter/ArrayPresenter.php
@@ -37,6 +37,7 @@ class ArrayPresenter extends RecursivePresenter
      * Present a reference to the array.
      *
      * @param array $value
+     * @param bool $color
      *
      * @return string
      */
@@ -72,12 +73,13 @@ class ArrayPresenter extends RecursivePresenter
      * Present the array.
      *
      * @param object $value
-     * @param int    $depth (default: null)
-     * @param bool   $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    protected function presentValue($value, $depth = null, $color = false)
+    protected function presentValue($value, $depth = null, $color = false, $options = 0)
     {
         $prefix = '';
         if ($value instanceof \ArrayObject) {

--- a/src/Psy/Presenter/ClosurePresenter.php
+++ b/src/Psy/Presenter/ClosurePresenter.php
@@ -48,6 +48,7 @@ class ClosurePresenter implements Presenter, PresenterManagerAware
      * Present a reference to the value.
      *
      * @param mixed $value
+     * @param bool $color
      *
      * @return string
      */
@@ -66,12 +67,13 @@ class ClosurePresenter implements Presenter, PresenterManagerAware
      * Present the Closure.
      *
      * @param \Closure $value
-     * @param int      $depth (default:null)
-     * @param bool     $color (default: false)
+     * @param int $depth (default:null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    public function present($value, $depth = null, $color = false)
+    public function present($value, $depth = null, $color = false, $options = 0)
     {
         return $this->presentRef($value, $color);
     }

--- a/src/Psy/Presenter/ExceptionPresenter.php
+++ b/src/Psy/Presenter/ExceptionPresenter.php
@@ -31,12 +31,13 @@ class ExceptionPresenter extends ObjectPresenter
     /**
      * Get an array of exception object properties.
      *
-     * @param object           $value
+     * @param object $value
      * @param \ReflectionClass $class
+     * @param int $options One of Presenter constants
      *
      * @return array
      */
-    protected function getProperties($value, \ReflectionClass $class)
+    protected function getProperties($value, \ReflectionClass $class, $options = 0)
     {
         $props = array(
             'message'  => $value->getMessage(),
@@ -46,6 +47,6 @@ class ExceptionPresenter extends ObjectPresenter
             'previous' => $value->getPrevious(),
         );
 
-        return array_merge(array_filter($props), parent::getProperties($value, $class));
+        return array_merge(array_filter($props), parent::getProperties($value, $class, $options));
     }
 }

--- a/src/Psy/Presenter/MongoCursorPresenter.php
+++ b/src/Psy/Presenter/MongoCursorPresenter.php
@@ -34,12 +34,13 @@ class MongoCursorPresenter extends ObjectPresenter
     /**
      * Get an array of object properties.
      *
-     * @param object           $value
+     * @param object $value
      * @param \ReflectionClass $class
+     * @param int $propertyFilter One of \ReflectionProperty constants
      *
      * @return array
      */
-    protected function getProperties($value, \ReflectionClass $class)
+    protected function getProperties($value, \ReflectionClass $class, $propertyFilter)
     {
         $info = $value->info();
 
@@ -54,7 +55,7 @@ class MongoCursorPresenter extends ObjectPresenter
 
         return array_merge(
             $info,
-            parent::getProperties($value, $class)
+            parent::getProperties($value, $class, $propertyFilter)
         );
     }
 

--- a/src/Psy/Presenter/PHPParserPresenter.php
+++ b/src/Psy/Presenter/PHPParserPresenter.php
@@ -37,6 +37,7 @@ class PHPParserPresenter extends ObjectPresenter
      * Present a reference to the object.
      *
      * @param object $value
+     * @param bool $color
      *
      * @return string
      */
@@ -50,12 +51,13 @@ class PHPParserPresenter extends ObjectPresenter
     /**
      * Get an array of object properties.
      *
-     * @param object           $value
+     * @param object $value
      * @param \ReflectionClass $class
+     * @param int $propertyFilter One of \ReflectionProperty constants
      *
      * @return array
      */
-    protected function getProperties($value, \ReflectionClass $class)
+    protected function getProperties($value, \ReflectionClass $class, $propertyFilter)
     {
         $props = array();
 

--- a/src/Psy/Presenter/Presenter.php
+++ b/src/Psy/Presenter/Presenter.php
@@ -17,6 +17,8 @@ namespace Psy\Presenter;
  */
 interface Presenter
 {
+    const VERBOSE = 1;
+
     /**
      * Check whether this Presenter can present $value.
      *
@@ -29,7 +31,7 @@ interface Presenter
     /**
      * Present a reference to the value.
      *
-     * @param mixed   $value
+     * @param mixed $value
      * @param Boolean $color
      *
      * @return string
@@ -42,10 +44,11 @@ interface Presenter
      * Optionally pass a $depth argument to limit the depth of recursive values.
      *
      * @param mixed $value
-     * @param int   $depth (default: null)
-     * @param bool  $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    public function present($value, $depth = null, $color = false);
+    public function present($value, $depth = null, $color = false, $options = 0);
 }

--- a/src/Psy/Presenter/PresenterManager.php
+++ b/src/Psy/Presenter/PresenterManager.php
@@ -88,10 +88,11 @@ class PresenterManager implements Presenter, \IteratorAggregate
     /**
      * Present a reference to the value.
      *
-     * @throws InvalidArgumentException If no Presenter is registered for $value
      *
      * @param mixed $value
+     * @param bool $color
      *
+     * @throws \InvalidArgumentException If no Presenter is registered for $value
      * @return string
      */
     public function presentRef($value, $color = false)
@@ -106,18 +107,19 @@ class PresenterManager implements Presenter, \IteratorAggregate
     /**
      * Present a full representation of the value.
      *
-     * @throws InvalidArgumentException If no Presenter is registered for $value
      *
      * @param mixed $value
-     * @param int   $depth (default: null)
-     * @param bool  $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
+     * @throws \InvalidArgumentException If no Presenter is registered for $value
      * @return string
      */
-    public function present($value, $depth = null, $color = false)
+    public function present($value, $depth = null, $color = false, $options = 0)
     {
         if ($presenter = $this->getPresenter($value)) {
-            return $presenter->present($value, $depth, $color);
+            return $presenter->present($value, $depth, $color, $options);
         }
 
         throw new \InvalidArgumentException(sprintf('Unable to present %s', $value));

--- a/src/Psy/Presenter/RecursivePresenter.php
+++ b/src/Psy/Presenter/RecursivePresenter.php
@@ -41,16 +41,17 @@ abstract class RecursivePresenter implements Presenter, PresenterManagerAware
      * @see self::presentValue()
      *
      * @param mixed $value
-     * @param int   $depth (default: null)
-     * @param bool  $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    public function present($value, $depth = null, $color = false)
+    public function present($value, $depth = null, $color = false, $options = 0)
     {
         $this->setDepth($depth);
 
-        return $this->presentValue($value, $depth, $color);
+        return $this->presentValue($value, $depth, $color, $options);
     }
 
     /**
@@ -58,7 +59,7 @@ abstract class RecursivePresenter implements Presenter, PresenterManagerAware
      * actually doing the presentation.
      *
      * @param mixed $value
-     * @param bool  $color (default: false)
+     * @param bool $color (default: false)
      *
      * @return string
      */
@@ -87,15 +88,16 @@ abstract class RecursivePresenter implements Presenter, PresenterManagerAware
      * @see PresenterManager::presentRef()
      *
      * @param mixed $value
-     * @param bool  $color (default: false)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    protected function presentSubValue($value, $color = false)
+    protected function presentSubValue($value, $color = false, $options = 0)
     {
         $depth = $this->depth;
         if ($depth > 0) {
-            $formatted = $this->manager->present($value, $depth - 1, $color);
+            $formatted = $this->manager->present($value, $depth - 1, $color, $options);
             $this->setDepth($depth);
 
             return $formatted;

--- a/src/Psy/Presenter/ResourcePresenter.php
+++ b/src/Psy/Presenter/ResourcePresenter.php
@@ -35,6 +35,7 @@ class ResourcePresenter implements Presenter
      * Present a reference to the value.
      *
      * @param mixed $value
+     * @param bool $color
      *
      * @return string
      */
@@ -56,12 +57,13 @@ class ResourcePresenter implements Presenter
      * Present the resource.
      *
      * @param resource $value
-     * @param int      $depth (default: null)
-     * @param bool     $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    public function present($value, $depth = null, $color = false)
+    public function present($value, $depth = null, $color = false, $options = 0)
     {
         return $this->presentRef($value, $color);
     }

--- a/src/Psy/Presenter/ScalarPresenter.php
+++ b/src/Psy/Presenter/ScalarPresenter.php
@@ -38,6 +38,7 @@ class ScalarPresenter implements Presenter
      * Present a reference to the value.
      *
      * @param mixed $value
+     * @param bool $color
      *
      * @return string
      */
@@ -50,12 +51,13 @@ class ScalarPresenter implements Presenter
      * Present the scalar value.
      *
      * @param mixed $value
-     * @param int   $depth (default: null)
-     * @param bool  $color (default: false)
+     * @param int $depth (default: null)
+     * @param bool $color (default: false)
+     * @param int $options One of Presenter constants
      *
      * @return string
      */
-    public function present($value, $depth = null, $color = false)
+    public function present($value, $depth = null, $color = false, $options = 0)
     {
         $formatted = $this->format($value);
 

--- a/test/Psy/Test/Presenter/Fixtures/SimpleClass.php
+++ b/test/Psy/Test/Presenter/Fixtures/SimpleClass.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Psy Shell
+ *
+ * (c) 2012-2014 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\Presenter\Fixtures;
+
+class SimpleClass
+{
+    public $hello = 'Hello world!';
+
+    protected $foo = 'bar';
+
+    private $secret = 42;
+}

--- a/test/Psy/Test/Presenter/ObjectPresenterTest.php
+++ b/test/Psy/Test/Presenter/ObjectPresenterTest.php
@@ -13,8 +13,10 @@ namespace Psy\Test\Presenter;
 
 use Psy\Presenter\ArrayPresenter;
 use Psy\Presenter\ObjectPresenter;
+use Psy\Presenter\Presenter;
 use Psy\Presenter\PresenterManager;
 use Psy\Presenter\ScalarPresenter;
+use Psy\Test\Presenter\Fixtures\SimpleClass;
 
 class ObjectPresenterTest extends \PHPUnit_Framework_TestCase
 {
@@ -101,5 +103,21 @@ EOS;
 
         $this->assertStringMatchesFormat('\<stdClass #%s>', $formatted);
         $this->assertContains(spl_object_hash($obj), $formatted);
+    }
+
+    public function testPresentVerbose()
+    {
+        $obj = new SimpleClass();
+        $hash = spl_object_hash($obj);
+
+        $expected = <<<EOS
+\<Psy\Test\Presenter\Fixtures\SimpleClass #$hash> {
+    hello: "Hello world!",
+    foo: "bar",
+    secret: 42
+}
+EOS;
+
+        $this->assertStringMatchesFormat($expected, $this->presenter->present($obj, null, false, Presenter::VERBOSE));
     }
 }


### PR DESCRIPTION
`dump` command now accepts `--all` / `-a` option.
This makes it possible to display protected and private properties.

Presenter interface has been updated in that regard, and all implemented presenters.

Cheers :octocat: 
