### PR TITLE
Php-Parser 1.0 stable was released. Use it instead of relying on `@dev` ...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/console": ">=2.3.10, <2.6.0",
-        "nikic/php-parser": "~1.0@dev",
+        "nikic/php-parser": "~1.0",
         "dnoegel/php-xdg-base-dir": "dev-master@dev"
     },
     "require-dev": {


### PR DESCRIPTION
...version
