### PR TITLE
Updated dev-dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "dnoegel/php-xdg-base-dir": "0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=3.7, <4.3",
-        "symfony/finder": "~2.1"
+        "phpunit/phpunit": "~4.0",
+        "symfony/finder": "~2.3"
     },
     "suggest": {
         "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",


### PR DESCRIPTION
We don't need to be so free with dev-dependencies since they only affect people directly using this repo, and not people requiring it with other dependencies in a project/package.
