### PR TITLE
Fixed the dnoegel/php-xdg-base-dir constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0",
         "symfony/console": "~2.3.10|~2.4.2|~2.5",
         "nikic/php-parser": "~1.0",
-        "dnoegel/php-xdg-base-dir": "0.1"
+        "dnoegel/php-xdg-base-dir": "0.1.*"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7, <4.3",


### PR DESCRIPTION
Surely we don't want to lock to `0.1.0`, and allow `0.1.x`?
