### PR TITLE
Add a cleaner debug startup statement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "ext-readline": "Enables support for arrow-key history navigation, and showing and manipulating command history."
     },
     "autoload": {
+        "files": ["src/Psy/functions.php"],
         "psr-0": {
             "Psy\\": "src/"
         }

--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Psy;
+
+/**
+ * Command to return the eval-able code to startup PsySH.
+ *
+ * ~~~php
+ * eval(\Psy\sh());
+ * ~~~
+ *
+ * @return string
+ */
+function sh()
+{
+    return "extract(\Psy\Shell::debug(get_defined_vars()));";
+}


### PR DESCRIPTION
``` php
eval(\Psy\sh());
```

``` php
extract(\Psy\Shell::debug(get_defined_vars()));
```
