### PR TITLE
Better PHPUnit version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "jakub-onderka/php-console-highlighter": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=3.7, <4.3",
+        "phpunit/phpunit": "~3.7|~4.0",
         "symfony/finder": "~2.1",
         "squizlabs/php_codesniffer": "~2.0"
     },


### PR DESCRIPTION
Since global composer installs are weird, we should probably open the PHPUnit version constraint up a bit.

/cc @GrahamCampbell
