### PR TITLE
Reference the correct backtrace variable in the Whereami command.

### DIFF
--- a/src/Psy/Command/WhereamiCommand.php
+++ b/src/Psy/Command/WhereamiCommand.php
@@ -72,7 +72,7 @@ HELP
             }
         }
 
-        return $backtrace[count($backtrace) - 1];
+        return $this->backtrace[count($backtrace) - 1];
     }
 
     /**


### PR DESCRIPTION
Fixes #133 

An easter egg would have made the code a big uglier since this error was in trace and would need to bubble up  and each function would need it's own exceptions for it. Icky < Boring
