### PR TITLE
Shorter syntax for the debug shell

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/console": "~2.3.10|~2.4.2|~2.5",
         "nikic/php-parser": "~1.0",
         "dnoegel/php-xdg-base-dir": "0.1",
-        "jakub-onderka/php-console-highlighter": "0.3.*"
+        "jakub-onderka/php-console-highlighter": "0.3.*",
+        "jeremeamia/SuperClosure": "@stable"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7|~4.0",

--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -2,6 +2,8 @@
 
 namespace Psy;
 
+use SuperClosure\Analyzer\TokenAnalyzer;
+
 /**
  * Command to return the eval-able code to startup PsySH.
  *
@@ -12,4 +14,38 @@ namespace Psy;
 function sh()
 {
     return 'extract(\Psy\Shell::debug(get_defined_vars(), $this ?: null));';
+}
+
+function dbg()
+{
+    list(,$caller) = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
+
+    $object = null;
+    if (array_key_exists('object', $caller)) {
+        $object = $caller['object'];
+        $method = $caller['function'];
+        $args = $caller['args'];
+        $reflectionMethod = new \ReflectionMethod($object, $caller['function']);
+        $closure = $reflectionMethod->getClosure($object);
+
+        $analyzer = new TokenAnalyzer();
+        $result = $analyzer->analyze($closure);
+        $code = $result['code'];
+        $code = str_replace('\Psy\brk();', '\Psy\Shell::debug(get_defined_vars(), $this?: null);', $code);
+        eval($code);
+
+        if ($result['hasThis']) {
+            $reflectionMethod = new \ReflectionFunction($method);
+            call_user_func_array(
+                \Closure::bind(
+                    $reflectionMethod->getClosure(),
+                    $result['binding'],
+                    get_class($result['binding'])
+                ),
+                $args
+            );
+        } else {
+            call_user_func_array($method, $args);
+        }
+    }
 }


### PR DESCRIPTION
It adds another dependency based on the library SuperClosure, but it leaves a shell call with a shorter syntax. Feel free to modify the function , reject the PR or whatever. I can have this only on my fork, but i thought it could be interesting for you