### PR TITLE
Don't include args in the whereami backtrace.

### DIFF
--- a/src/Psy/Command/WhereamiCommand.php
+++ b/src/Psy/Command/WhereamiCommand.php
@@ -25,7 +25,7 @@ class WhereamiCommand extends Command
 {
     public function __construct()
     {
-        $this->backtrace = debug_backtrace();
+        $this->backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
         return parent::__construct();
     }


### PR DESCRIPTION
Saves us a bit of memory and complexity, at the very least.

We could also probably limit the backtrace to some sane number of stack frames, but that's a bit risky because inside evals or closures or generated code (SuperClosure, etc) it can get deeper than you'd expect.

/cc @blainesch 