### PR TITLE
Prevent function redeclaration.

### DIFF
--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -2,14 +2,16 @@
 
 namespace Psy;
 
-/**
- * Command to return the eval-able code to startup PsySH.
- *
- *     eval(\Psy\sh());
- *
- * @return string
- */
-function sh()
-{
-    return 'extract(\Psy\Shell::debug(get_defined_vars(), $this ?: null));';
+if (!function_exists('Psy\sh')) {
+    /**
+     * Command to return the eval-able code to startup PsySH.
+     *
+     *     eval(\Psy\sh());
+     *
+     * @return string
+     */
+    function sh()
+    {
+        return 'extract(\Psy\Shell::debug(get_defined_vars(), $this ?: null));';
+    }
 }


### PR DESCRIPTION
On a system that has PsySH installed globally, running *any* global composer command on a project that has PsySH installed locally might cause composer to load `Psy\functions.php` from both the global and the local context. This will result in a function redeclaration error.