### PR TITLE
Fixes #106 by adjusting how loop closures are unbound.

### DIFF
--- a/src/Psy/ExecutionLoop/Loop.php
+++ b/src/Psy/ExecutionLoop/Loop.php
@@ -106,7 +106,7 @@ class Loop
             if (is_object($that)) {
                 $loop = $loop->bindTo($that, get_class($that));
             } else {
-                $loop = $loop->bindTo(null);
+                $loop = $loop->bindTo(null, null);
             }
         }
 


### PR DESCRIPTION
This PR is a small change that fixes #106. While b3ec103 seems like a valid approach, this PR might be an easier way to do it.

If you do `->bindTo(null)`, then you forever make the closure "static".

However, if you do `->bindTo(null, null)`, for some reason, you can rebind later without an issue.

Why? I'm not really sure, but that is just how it works. I [prepared this gist](https://gist.github.com/jeremeamia/63912686640adb402c6d) showing how different binding situations work out.