### PR TITLE
Workaround PHP bug #69054 and other issues with open_basedir

### DIFF
--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -129,12 +129,12 @@ class Configuration
 
         foreach ($this->getConfigDirs() as $dir) {
             $file = $dir . '/config.php';
-            if (is_file($file)) {
+            if (@is_file($file)) {
                 return $this->configFile = $file;
             }
 
             $file = $dir . '/rc.php';
-            if (is_file($file)) {
+            if (@is_file($file)) {
                 return $this->configFile = $file;
             }
         }
@@ -397,12 +397,12 @@ class Configuration
 
         foreach ($this->getConfigDirs() as $dir) {
             $file = $dir . '/psysh_history';
-            if (is_file($file)) {
+            if (@is_file($file)) {
                 return $this->historyFile = $file;
             }
 
             $file = $dir . '/history';
-            if (is_file($file)) {
+            if (@is_file($file)) {
                 return $this->historyFile = $file;
             }
         }
@@ -838,7 +838,7 @@ class Configuration
 
         foreach ($this->getDataDirs() as $dir) {
             $file = $dir . '/php_manual.sqlite';
-            if (is_file($file)) {
+            if (@is_file($file)) {
                 return $this->manualDbFile = $file;
             }
         }

--- a/src/Psy/Readline/GNUReadline.php
+++ b/src/Psy/Readline/GNUReadline.php
@@ -83,7 +83,11 @@ class GNUReadline implements Readline
      */
     public function readHistory()
     {
-        readline_read_history();
+        /* Workaround PHP bug #69054
+         * If open_basedir is set, readline_read_history() segfaults */
+        if (!ini_get('open_basedir')) {
+            readline_read_history();
+        }
         readline_clear_history();
 
         return readline_read_history($this->historyFile);


### PR DESCRIPTION
[PHP bug #69054][1] is a segfault when calling readline_read_history() with no parameters when open_basedir is set.

This commit also adds a few @ before is_file() calls in Configuration which may throw ErrorException due to open_basedir

Related: #99

[1]: https://bugs.php.net/bug.php?id=69054