### PR TITLE
Make psysh play nicer as a global install

### DIFF
--- a/bin/psysh
+++ b/bin/psysh
@@ -82,9 +82,8 @@ if (!class_exists('\Psy\Shell')) {
     } elseif (is_file(__DIR__ . '/../../../autoload.php')) {
         require __DIR__ . '/../../../autoload.php';
     } else {
-        echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
-        echo 'curl -sS https://getcomposer.org/installer | php' . PHP_EOL;
-        echo 'php composer.phar install' . PHP_EOL;
+        echo 'PsySH dependencies not found, be sure to run `composer install`.' . PHP_EOL;
+        echo 'See https://getcomposer.org to get Composer.' . PHP_EOL;
         exit(1);
     }
 /* >>> */

--- a/bin/psysh
+++ b/bin/psysh
@@ -49,7 +49,10 @@ call_user_func(function() {
                 if (isset($cfg['name']) && $cfg['name'] === 'psy/psysh') {
                     // We're inside the psysh project. Let's use the local
                     // Composer autoload.
-                    require $path . '/vendor/autoload.php';
+                    if (is_file($path . '/vendor/autoload.php')) {
+                        require $path . '/vendor/autoload.php';
+                    }
+
                     return;
                 }
             }
@@ -62,7 +65,10 @@ call_user_func(function() {
                     if (isset($pkg['name']) && $pkg['name'] === 'psy/psysh') {
                         // We're inside a project which requires psysh. We'll
                         // use the local Composer autoload.
-                        require $path . '/vendor/autoload.php';
+                        if (is_file($path . '/vendor/autoload.php')) {
+                            require $path . '/vendor/autoload.php';
+                        }
+
                         return;
                     }
                 }

--- a/bin/psysh
+++ b/bin/psysh
@@ -10,18 +10,62 @@
  * file that was distributed with this source code.
  */
 
+// Try to find an autoloader for a local psysh version.
+// We'll wrap this whole mess in a Closure so it doesn't leak any globals.
+call_user_func(function() {
+    $cwd = getcwd();
+    $cwd = str_replace('\\', '/', $cwd);
+
+    $chunks = explode('/', $cwd);
+    while (!empty($chunks)) {
+        $path = implode('/', $chunks);
+
+        // Find composer.json
+        if (is_file($path . '/composer.json')) {
+            if ($cfg = json_decode(file_get_contents($path . '/composer.json'), true)) {
+                if (isset($cfg['name']) && $cfg['name'] === 'psy/psysh') {
+                    // We're inside the psysh project. Let's use the local
+                    // Composer autoload.
+                    require($path . '/vendor/autoload.php');
+                    return;
+                }
+            }
+        }
+
+        // Or a composer.lock
+        if (is_file($path . '/composer.lock')) {
+            if ($cfg = json_decode(file_get_contents($path . '/composer.lock'), true)) {
+                foreach (array_merge($cfg['packages'], $cfg['packages-dev']) as $pkg) {
+                    if (isset($pkg['name']) && $pkg['name'] === 'psy/psysh') {
+                        // We're inside a project which requires psysh. We'll
+                        // use the local Composer autoload.
+                        require($path . '/vendor/autoload.php');
+                        return;
+                    }
+                }
+            }
+        }
+
+        array_pop($chunks);
+    }
+});
+
+// We didn't find an autoloader for a local version, so use the autoloader that
+// came with this script.
+if (!class_exists('\Psy\Shell')) {
 /* <<< */
-if (is_file(__DIR__ . '/../vendor/autoload.php')) {
-    require(__DIR__ . '/../vendor/autoload.php');
-} elseif (is_file(__DIR__ . '/../../../autoload.php')) {
-    require(__DIR__ . '/../../../autoload.php');
-} else {
-    echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
-    echo 'curl -s http://getcomposer.org/installer | php' . PHP_EOL;
-    echo 'php composer.phar install' . PHP_EOL;
-    exit(1);
-}
+    if (is_file(__DIR__ . '/../vendor/autoload.php')) {
+        require(__DIR__ . '/../vendor/autoload.php');
+    } elseif (is_file(__DIR__ . '/../../../autoload.php')) {
+        require(__DIR__ . '/../../../autoload.php');
+    } else {
+        echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
+        echo 'curl -s http://getcomposer.org/installer | php' . PHP_EOL;
+        echo 'php composer.phar install' . PHP_EOL;
+        exit(1);
+    }
 /* >>> */
+}
 
 // If the psysh binary was included directly, assume they just wanted an
 // autoloader and bail early.
@@ -41,6 +85,22 @@ if (\Psy\Shell::isIncluded($trace)) {
 
 // Clean up after ourselves.
 unset($trace);
+
+// If the local version is too old, we can't do this
+if (!function_exists('\Psy\bin')) {
+    $argv = $_SERVER['argv'];
+    $first = array_shift($argv);
+    if (preg_match('/php(\.exe)?$/', $first)) {
+        array_shift($argv);
+    }
+    array_unshift($argv, 'vendor/bin/psysh');
+
+    echo 'A local PsySH dependency was found, but it cannot be loaded. Please update to' . PHP_EOL;
+    echo 'the latest version, or run the local copy directly, e.g.:' . PHP_EOL;
+    echo PHP_EOL;
+    echo '    ' . implode(' ', $argv) . PHP_EOL;
+    exit(1);
+}
 
 // And go!
 call_user_func(\Psy\bin());

--- a/bin/psysh
+++ b/bin/psysh
@@ -23,13 +23,6 @@ if (is_file(__DIR__ . '/../vendor/autoload.php')) {
 }
 /* >>> */
 
-use Psy\Configuration;
-use Psy\Shell;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
-
 // If the psysh binary was included directly, assume they just wanted an
 // autoloader and bail early.
 if (version_compare(PHP_VERSION, '5.3.6', '<')) {
@@ -40,7 +33,7 @@ if (version_compare(PHP_VERSION, '5.3.6', '<')) {
     $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
 }
 
-if (Shell::isIncluded($trace)) {
+if (\Psy\Shell::isIncluded($trace)) {
     unset($trace);
 
     return;
@@ -49,74 +42,5 @@ if (Shell::isIncluded($trace)) {
 // Clean up after ourselves.
 unset($trace);
 
-call_user_func(function() {
-    $usageException = null;
-
-    $input = new ArgvInput();
-    try {
-        $input->bind(new InputDefinition(array(
-            new InputOption('help',    'h', InputOption::VALUE_NONE),
-            new InputOption('config',  'c', InputOption::VALUE_REQUIRED),
-            new InputOption('version', 'v', InputOption::VALUE_NONE),
-
-            new InputArgument('include', InputArgument::IS_ARRAY),
-        )));
-    } catch (\RuntimeException $e) {
-        $usageException = $e;
-    }
-
-    $config = array();
-
-    // Handle --config
-    if ($configFile = $input->getOption('config')) {
-        $config['configFile'] = $configFile;
-    }
-
-    $shell = new Shell(new Configuration($config));
-
-    // Handle --help
-    if ($usageException !== null || $input->getOption('help')) {
-        if ($usageException !== null) {
-            echo $usageException->getMessage() . PHP_EOL . PHP_EOL;
-        }
-
-        $version = $shell->getVersion();
-        $name    = basename(reset($_SERVER['argv']));
-        echo <<<EOL
-$version
-
-Usage:
-  $name [--version] [--help] [files...]
-
-Options:
-  --help     -h Display this help message.
-  --config   -c Use an alternate PsySH config file location.
-  --version  -v Display the PsySH version.
-
-EOL;
-        exit($usageException === null ? 0 : 1);
-    }
-
-
-    // Handle --version
-    if ($input->getOption('version')) {
-        echo $shell->getVersion() . PHP_EOL;
-        exit(0);
-    }
-
-    // Pass additional arguments to Shell as 'includes'
-    $shell->setIncludes($input->getArgument('include'));
-
-    try {
-        // And go!
-        $shell->run();
-    } catch (Exception $e) {
-        echo $e->getMessage() . PHP_EOL;
-
-        // TODO: this triggers the "exited unexpectedly" logic in the
-        // ForkingLoop, so we can't exit(1) after starting the shell...
-        // fix this :)
-
-        // exit(1);
-    }
-});
+// And go!
+call_user_func(\Psy\bin());

--- a/bin/psysh
+++ b/bin/psysh
@@ -83,7 +83,7 @@ if (!class_exists('\Psy\Shell')) {
         require __DIR__ . '/../../../autoload.php';
     } else {
         echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
-        echo 'curl -s http://getcomposer.org/installer | php' . PHP_EOL;
+        echo 'curl -sS https://getcomposer.org/installer | php' . PHP_EOL;
         echo 'php composer.phar install' . PHP_EOL;
         exit(1);
     }

--- a/bin/psysh
+++ b/bin/psysh
@@ -16,11 +16,10 @@ if (is_file(__DIR__ . '/../vendor/autoload.php')) {
 } elseif (is_file(__DIR__ . '/../../../autoload.php')) {
     require(__DIR__ . '/../../../autoload.php');
 } else {
-    die(
-        'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL .
-        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
-        'php composer.phar install' . PHP_EOL
-    );
+    echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
+    echo 'curl -s http://getcomposer.org/installer | php' . PHP_EOL;
+    echo 'php composer.phar install' . PHP_EOL;
+    exit(1);
 }
 /* >>> */
 

--- a/bin/psysh
+++ b/bin/psysh
@@ -49,7 +49,7 @@ call_user_func(function() {
                 if (isset($cfg['name']) && $cfg['name'] === 'psy/psysh') {
                     // We're inside the psysh project. Let's use the local
                     // Composer autoload.
-                    require($path . '/vendor/autoload.php');
+                    require $path . '/vendor/autoload.php';
                     return;
                 }
             }
@@ -62,7 +62,7 @@ call_user_func(function() {
                     if (isset($pkg['name']) && $pkg['name'] === 'psy/psysh') {
                         // We're inside a project which requires psysh. We'll
                         // use the local Composer autoload.
-                        require($path . '/vendor/autoload.php');
+                        require $path . '/vendor/autoload.php';
                         return;
                     }
                 }
@@ -78,9 +78,9 @@ call_user_func(function() {
 if (!class_exists('\Psy\Shell')) {
 /* <<< */
     if (is_file(__DIR__ . '/../vendor/autoload.php')) {
-        require(__DIR__ . '/../vendor/autoload.php');
+        require __DIR__ . '/../vendor/autoload.php';
     } elseif (is_file(__DIR__ . '/../../../autoload.php')) {
-        require(__DIR__ . '/../../../autoload.php');
+        require __DIR__ . '/../../../autoload.php';
     } else {
         echo 'You must set up the Psy Shell dependencies, run the following commands:' . PHP_EOL;
         echo 'curl -s http://getcomposer.org/installer | php' . PHP_EOL;

--- a/bin/psysh
+++ b/bin/psysh
@@ -13,7 +13,30 @@
 // Try to find an autoloader for a local psysh version.
 // We'll wrap this whole mess in a Closure so it doesn't leak any globals.
 call_user_func(function() {
-    $cwd = getcwd();
+    $cwd = null;
+
+    // Find the cwd arg (if present)
+    foreach ($_SERVER['argv'] as $i => $arg) {
+        if ($arg === '--cwd') {
+            if ($i >= count($_SERVER['argv']) - 1) {
+                echo 'Missing --cwd argument.' . PHP_EOL;
+                exit(1);
+            }
+            $cwd = $_SERVER['argv'][$i + 1];
+            break;
+        }
+
+        if (preg_match('/^--cwd=/', $arg)) {
+            $cwd = substr($arg, 6);
+            break;
+        }
+    }
+
+    // Or fall back to the actual cwd
+    if (!isset($cwd)) {
+        $cwd = getcwd();
+    }
+
     $cwd = str_replace('\\', '/', $cwd);
 
     $chunks = explode('/', $cwd);

--- a/src/Psy/Compiler.php
+++ b/src/Psy/Compiler.php
@@ -155,7 +155,7 @@ EOS;
 
         $content = file_get_contents(__DIR__ . '/../../bin/psysh');
         $content = preg_replace('{/\* <<<.*?>>> \*/}sm', $autoload, $content);
-        $content .= "__halt_compiler();";
+        $content .= '__HALT_COMPILER();';
 
         return $content;
     }

--- a/src/Psy/Compiler.php
+++ b/src/Psy/Compiler.php
@@ -149,13 +149,13 @@ class Compiler
     private function getStub()
     {
         $autoload = <<<'EOS'
-Phar::mapPhar('psysh.phar');
-require 'phar://psysh.phar/vendor/autoload.php';
+    Phar::mapPhar('psysh.phar');
+    require 'phar://psysh.phar/vendor/autoload.php';
 EOS;
 
         $content = file_get_contents(__DIR__ . '/../../bin/psysh');
         $content = preg_replace('{/\* <<<.*?>>> \*/}sm', $autoload, $content);
-        $content .= "__HALT_COMPILER();";
+        $content .= "__halt_compiler();";
 
         return $content;
     }

--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -126,9 +126,10 @@ if (!function_exists('Psy\bin')) {
             $input = new ArgvInput();
             try {
                 $input->bind(new InputDefinition(array(
-                    new InputOption('help',    'h', InputOption::VALUE_NONE),
-                    new InputOption('config',  'c', InputOption::VALUE_REQUIRED),
-                    new InputOption('version', 'v', InputOption::VALUE_NONE),
+                    new InputOption('help',    'h',  InputOption::VALUE_NONE),
+                    new InputOption('config',  'c',  InputOption::VALUE_REQUIRED),
+                    new InputOption('version', 'v',  InputOption::VALUE_NONE),
+                    new InputOption('cwd',     null, InputOption::VALUE_REQUIRED),
 
                     new InputArgument('include', InputArgument::IS_ARRAY),
                 )));
@@ -162,6 +163,7 @@ Usage:
 Options:
   --help     -h Display this help message.
   --config   -c Use an alternate PsySH config file location.
+  --cwd         Use an alternate working directory.
   --version  -v Display the PsySH version.
 
 EOL;

--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -2,6 +2,11 @@
 
 namespace Psy;
 
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
 if (!function_exists('Psy\sh')) {
     /**
      * Command to return the eval-able code to startup PsySH.
@@ -104,5 +109,86 @@ if (!function_exists('Psy\info')) {
         );
 
         return array_merge($core, compact('pcntl', 'readline', 'history', 'docs', 'autocomplete'));
+    }
+}
+
+if (!function_exists('Psy\bin')) {
+    /**
+     * `psysh` command line executable.
+     *
+     * @return Closure
+     */
+    function bin()
+    {
+        return function () {
+            $usageException = null;
+
+            $input = new ArgvInput();
+            try {
+                $input->bind(new InputDefinition(array(
+                    new InputOption('help',    'h', InputOption::VALUE_NONE),
+                    new InputOption('config',  'c', InputOption::VALUE_REQUIRED),
+                    new InputOption('version', 'v', InputOption::VALUE_NONE),
+
+                    new InputArgument('include', InputArgument::IS_ARRAY),
+                )));
+            } catch (\RuntimeException $e) {
+                $usageException = $e;
+            }
+
+            $config = array();
+
+            // Handle --config
+            if ($configFile = $input->getOption('config')) {
+                $config['configFile'] = $configFile;
+            }
+
+            $shell = new Shell(new Configuration($config));
+
+            // Handle --help
+            if ($usageException !== null || $input->getOption('help')) {
+                if ($usageException !== null) {
+                    echo $usageException->getMessage() . PHP_EOL . PHP_EOL;
+                }
+
+                $version = $shell->getVersion();
+                $name    = basename(reset($_SERVER['argv']));
+                echo <<<EOL
+$version
+
+Usage:
+  $name [--version] [--help] [files...]
+
+Options:
+  --help     -h Display this help message.
+  --config   -c Use an alternate PsySH config file location.
+  --version  -v Display the PsySH version.
+
+EOL;
+                exit($usageException === null ? 0 : 1);
+            }
+
+            // Handle --version
+            if ($input->getOption('version')) {
+                echo $shell->getVersion() . PHP_EOL;
+                exit(0);
+            }
+
+            // Pass additional arguments to Shell as 'includes'
+            $shell->setIncludes($input->getArgument('include'));
+
+            try {
+                // And go!
+                $shell->run();
+            } catch (Exception $e) {
+                echo $e->getMessage() . PHP_EOL;
+
+                // TODO: this triggers the "exited unexpectedly" logic in the
+                // ForkingLoop, so we can't exit(1) after starting the shell...
+                // fix this :)
+
+                // exit(1);
+            }
+        };
     }
 }


### PR DESCRIPTION
Use a globally installed `psysh` bin script or phar as a "launcher" for a local version, if possible. Starting from the current working directory and moving up, check for 'psy/psysh' as a composer project or dependency. If found, load that one instead of the globally installed version.

This is basically what Gulp and a bunch of other JS projects do with their global installs as well.

This is a partial fix for #170. I think the rest of the fix is to stop recommending the non-phar install at all, in anything but a project scope. Instead, recommend installing the `psysh` phar somewhere in `$PATH`.