### PR TITLE
Fix uncatchable exception when requiring non-existent file

### DIFF
--- a/src/Psy/CodeCleaner.php
+++ b/src/Psy/CodeCleaner.php
@@ -26,6 +26,7 @@ use Psy\CodeCleaner\LeavePsyshAlonePass;
 use Psy\CodeCleaner\LegacyEmptyPass;
 use Psy\CodeCleaner\MagicConstantsPass;
 use Psy\CodeCleaner\NamespacePass;
+use Psy\CodeCleaner\RequirePass;
 use Psy\CodeCleaner\StaticConstructorPass;
 use Psy\CodeCleaner\UseStatementPass;
 use Psy\CodeCleaner\ValidClassNamePass;
@@ -86,6 +87,7 @@ class CodeCleaner
             new ValidClassNamePass(),
             new ValidConstantPass(),
             new MagicConstantsPass(),
+            new RequirePass(),
         );
     }
 

--- a/src/Psy/CodeCleaner/RequirePass.php
+++ b/src/Psy/CodeCleaner/RequirePass.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Psy\CodeCleaner;
+
+use PhpParser\Node;
+
+class RequirePass extends CodeCleanerPass
+{
+    public function enterNode(Node $node)
+    {
+        if ((
+            $node instanceof Node\Expr\Include_ &&
+            in_array($node->type, array(3, 4)) &&
+            !$node->getAttribute('included')
+        )) {
+            $injected = clone $node;
+            $injected->setAttribute('included', true);
+
+            return new Node\Expr\FuncCall(
+                new Node\Name('call_user_func'),
+                array(
+                    new Node\Arg(
+                        new Node\Expr\Closure(
+                            array(
+                                'params' => array(new Node\Param('class')),
+                                'stmts' => array(
+                                    new Node\Stmt\If_(
+                                        new Node\Expr\FuncCall(
+                                            new Node\Name('stream_resolve_include_path'),
+                                            array(new Node\Arg(new Node\Expr\Variable('class')))
+                                        ),
+                                        array(
+                                            'stmts' => array(new Node\Stmt\Return_($injected)),
+                                            'else' => new Node\Stmt\Else_(
+                                                array(
+                                                    new Node\Expr\FuncCall(
+                                                        new Node\Name('trigger_error'),
+                                                        array(
+                                                            new Node\Expr\FuncCall(
+                                                                new Node\Name('sprintf'),
+                                                                array(
+                                                                    new Node\Arg(new Node\Scalar\String('require(%s): failed to open stream: No such file or directory in php shell code on line %d')),
+                                                                    new Node\Arg(new Node\Expr\Variable('class')),
+                                                                    new Node\Arg(new Node\Scalar\DNumber($node->getLine())),
+                                                                )
+                                                            ),
+                                                        )
+                                                    ),
+                                                )
+                                            ),
+                                        )
+                                    ),
+                                ),
+                            )
+                        )
+                    ),
+                    new Node\Arg($node->expr),
+                ),
+                $node->getAttributes()
+            );
+        }
+    }
+}


### PR DESCRIPTION
For the require, and require_once the code cleaner wraps the nodes inside this :

``` php
return call_user_func(function ($class) {
  if (stream_resolve_include_path($class) {
    return require $class;
  } else {
     trigger_error(sprintf('require(%s): failed to open stream: No such file or directory in php shell code on line %d', $class, $node->getLine()));
 }
}, $class );
```

If the error is not enough, an exception can be added instead. but i thought that the warning might be enough because is the first thing that php throws on this kind of error.

See #175
