### PR TITLE
[Feature]multi line string editing

### DIFF
--- a/src/Psy/CodeBuffer.php
+++ b/src/Psy/CodeBuffer.php
@@ -27,6 +27,7 @@ class CodeBuffer
     private $buffer;
     private $open;
 
+    private $calculatedDepth;
     private $depth;
     private $inverse;
 
@@ -62,7 +63,7 @@ class CodeBuffer
      */
     public function isOpen()
     {
-        return $this->open && $this->depth > 0;
+        return $this->calculatedDepth > 0;
     }
 
     /**
@@ -120,17 +121,13 @@ class CodeBuffer
 
         if ($lastCharacter === $this->openOperator) {
             $this->open = true;
+
             $code = substr(rtrim($code), 0, -1);
-        } elseif ($this->depth >= 0) {
-            $this->open = true;
-        } elseif ($this->depth <= 0) {
+        } else {
             $this->open = false;
         }
 
-        if ($lastCharacter === ';') {
-            $this->open = false;
-            $this->depth = 0;
-        }
+        $this->calculatedDepth = $this->depth + $this->open;
 
         $this->buffer[] = $code;
     }
@@ -151,5 +148,6 @@ class CodeBuffer
         $this->buffer = array();
         $this->open = false;
         $this->depth = 0;
+        $this->calculatedDepth = 0;
     }
 }

--- a/src/Psy/CodeBuffer.php
+++ b/src/Psy/CodeBuffer.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of Psy Shell
+ *
+ * (c) 2012-2014 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy;
+
+/**
+ * Code buffer, keeps track of inputed code.
+ *
+ * @author volter9
+ */
+class CodeBuffer
+{
+    // Characters
+    private $openOperator = '\\';
+    private $oneLevel  = '/(?<!\\\\)(\'|")/';
+    // private $levelUp   = '/\{|\[|\(/';
+    // private $levelDown = '/\}|\]|\)/';
+
+    private $buffer;
+    private $open;
+
+    private $depth;
+    private $inverse;
+
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    /**
+     * Return array of lines of inputed code.
+     *
+     * @return array
+     */
+    public function getBuffer()
+    {
+        return $this->buffer;
+    }
+
+    /**
+     * Get depth of input code expressions.
+     *
+     * @return int
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     * Checks if the code buffer is open (the code isn't complited).
+     *
+     * @return bool
+     */
+    public function isOpen()
+    {
+        return $this->open && $this->depth > 0;
+    }
+
+    /**
+     * Checks whether code buffer is.
+     */
+    public function isEmpty()
+    {
+        return empty($this->buffer);
+    }
+
+    /**
+     * Adds code to the buffer.
+     *
+     * @param string $code
+     */
+    public function addCode($code)
+    {
+        $this->computeDepthSum($code);
+        $this->processCode($code);
+    }
+
+    /**
+     * Computes depth sum for keeping buffer open for opening/closening:
+     * brackets, square brackets and paranthesis.
+     *
+     * @param string $code
+     */
+    protected function computeDepthSum($code)
+    {
+        $one  = $this->countByRegEx($this->oneLevel, $code);
+        // $up   = $this->countByRegEx($this->levelUp, $code);
+        // $down = $this->countByRegEx($this->levelDown, $code);
+
+        $inverse = $this->inverse = (bool) ($this->inverse ^ $one % 2 === 1);
+        $factor = $inverse ? 1 : -1;
+
+        $this->depth += ($one % 2) * $factor; // + $up - $down;
+    }
+
+    private function countByRegEx($regEx, $string)
+    {
+        preg_match_all($regEx, $string, $matches);
+
+        return isset($matches[1]) ? count($matches[1]) : 0;
+    }
+
+    /**
+     * Processes the code and processes opening buffer operator '\'.
+     *
+     * @param string $code
+     */
+    protected function processCode($code)
+    {
+        $lastCharacter = substr(rtrim($code), -1);
+
+        if ($lastCharacter === $this->openOperator) {
+            $this->open = true;
+            $code = substr(rtrim($code), 0, -1);
+        } elseif ($this->depth >= 0) {
+            $this->open = true;
+        } elseif ($this->depth <= 0) {
+            $this->open = false;
+        }
+
+        if ($lastCharacter === ';') {
+            $this->open = false;
+            $this->depth = 0;
+        }
+
+        $this->buffer[] = $code;
+    }
+
+    /**
+     * Close the code buffer.
+     */
+    public function close()
+    {
+        $this->open = false;
+    }
+
+    /**
+     * Resets code buffer by setting its properties to default values.
+     */
+    public function reset()
+    {
+        $this->buffer = array();
+        $this->open = false;
+        $this->depth = 0;
+    }
+}


### PR DESCRIPTION
Hello there!

I recently discovered this awesome REPL for PHP (yesterday, actually :smiley: ). PsySH is great, but there's only one little detail that I miss from PHP's interactive mode (aka `php -a`), it's multiline string editing:

![Multiline string edit](http://i.gyazo.com/5c60c59418aa00a28f7e9e7cd88f66f5.png)

That's why I decided to "fix" the situation, behold of `string multi line edit` :smile::

![Working example](http://i.gyazo.com/49366f2145ddafa140d2153396c93432.png)

And current version with the same code:

![Current version non working example](http://i.gyazo.com/ed8fae0f35eadb4fc695e0f5b8052615.png)

Also, I decided to extract `$codeBuffer` and `codeBufferOpen` in separate class. I hope you okay with that, and also added @author tag in this class, I hope you're okay with that too (otherwise feel free to delete it) :blush: 

Thanks for PsySH! :smiley: 

P.S.: I didn't wrote tests yet for `\Psy\CodeBuffer`, do you want me to write unit tests for it, or it's fine?
P.S.S.: Also not sure about DI in `\Psy\Shell`, is it supposed to be injected through Configuration class and public getter or via Shell's setter?