### PR TITLE
Don't try and match where we've not been able to find the variable

### DIFF
--- a/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -41,7 +41,7 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
         try {
             $object = $this->getVariable($objectName);
         } catch (InvalidArgumentException $e) {
-            return [];
+            return array();
         }
 
         return array_filter(

--- a/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -11,6 +11,8 @@
 
 namespace Psy\TabCompletion\Matcher;
 
+use InvalidArgumentException;
+
 /**
  * An object attribute tab completion Matcher.
  *
@@ -35,7 +37,12 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
         }
         $objectToken = array_pop($tokens);
         $objectName = str_replace('$', '', $objectToken[1]);
-        $object = $this->getVariable($objectName);
+
+        try {
+            $object = $this->getVariable($objectName);
+        } catch (InvalidArgumentException $e) {
+            return [];
+        }
 
         return array_filter(
             array_keys(get_class_vars(get_class($object))),

--- a/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -41,7 +41,7 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
         try {
             $object = $this->getVariable($objectName);
         } catch (InvalidArgumentException $e) {
-            return [];
+            return array();
         }
 
         return array_filter(

--- a/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -11,6 +11,8 @@
 
 namespace Psy\TabCompletion\Matcher;
 
+use InvalidArgumentException;
+
 /**
  * An object method tab completion Matcher.
  *
@@ -35,7 +37,12 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
         }
         $objectToken = array_pop($tokens);
         $objectName = str_replace('$', '', $objectToken[1]);
-        $object = $this->getVariable($objectName);
+
+        try {
+            $object = $this->getVariable($objectName);
+        } catch (InvalidArgumentException $e) {
+            return [];
+        }
 
         return array_filter(
             get_class_methods($object),


### PR DESCRIPTION
At present, this includes

```
$app['something']->
$app->getSomething()->
```

etc.

It would be great to be able to parse back far enough, but I think that's quite a task