### PR TITLE
Critial fix to php-parser version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.9",
         "symfony/console": "~2.3.10|^2.4.2|~3.0",
         "symfony/var-dumper": "~2.7|~3.0",
-        "nikic/php-parser": "~1.2.1",
+        "nikic/php-parser": "~1.3",
         "dnoegel/php-xdg-base-dir": "0.1",
         "jakub-onderka/php-console-highlighter": "0.3.*"
     },


### PR DESCRIPTION
This is going to need a 0.5.1 release...