### PR TITLE
Fix incompatibility with Symfony\Component\Console\Application::renderException

### DIFF
--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -666,7 +666,7 @@ class Shell extends Application
      * @param \Exception      $e      An exception instance
      * @param OutputInterface $output An OutputInterface instance
      */
-    public function renderException($e, $output)
+    public function renderException(\Exception $e, OutputInterface $output)
     {
         $this->context->setLastException($e);
 


### PR DESCRIPTION
Symfony added typehinting on this method at some point, and it's now raising an error.

```
Whoops\Exception\ErrorException: Declaration of Psy\Shell::renderException() should be compatible with Symfony\Component\Console\Application::renderException(Exception $e, Symfony\Component\Console\Output\OutputInterface $output) in file /home/matt/Dropbox/Projects/iw.quickstart/vendor/psy/psysh/src/Psy/Shell.php on line 43
Stack trace:
  1. Whoops\Exception\ErrorException->() /home/matt/Dropbox/Projects/iw.quickstart/vendor/psy/psysh/src/Psy/Shell.php:43
  2. Whoops\Run->handleError() /home/matt/Dropbox/Projects/iw.quickstart/vendor/psy/psysh/src/Psy/Shell.php:43
  3. include() /home/matt/Dropbox/Projects/iw.quickstart/vendor/composer/ClassLoader.php:412
  4. Composer\Autoload\includeFile() /home/matt/Dropbox/Projects/iw.quickstart/vendor/composer/ClassLoader.php:301
  5. Composer\Autoload\ClassLoader->loadClass() :0
  6. spl_autoload_call() /home/matt/Dropbox/Projects/iw.quickstart/vendor/dotink/inkwell-console/src/Quill.php:8
  7. include() /home/matt/Dropbox/Projects/iw.quickstart/vendor/composer/ClassLoader.php:412
  8. Composer\Autoload\includeFile() /home/matt/Dropbox/Projects/iw.quickstart/vendor/composer/ClassLoader.php:301
  9. Composer\Autoload\ClassLoader->loadClass() :0
 10. spl_autoload_call() /home/matt/Dropbox/Projects/iw.quickstart/bin/quill:34
 11. {closure}() :0
 12. call_user_func_array() /home/matt/Dropbox/Projects/iw.quickstart/vendor/dotink/affinity/src/Engine.php:121
 13. Affinity\Engine->exec() /home/matt/Dropbox/Projects/iw.quickstart/vendor/dotink/inkwell-core/src/Core.php:188
 14. Inkwell\Core->run() /home/matt/Dropbox/Projects/iw.quickstart/bin/quill:86
```

This fixes it.