### PR TITLE
Add support for local config files

### DIFF
--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -105,6 +105,9 @@ class Configuration
      * This checks for the presence of Readline and Pcntl extensions.
      *
      * If a config file is available, it will be loaded and merged with the current config.
+     *
+     * If no custom config file was specified and a local project config file
+     * is available, it will be loaded and merged with the current config.
      */
     public function init()
     {
@@ -114,6 +117,10 @@ class Configuration
 
         if ($configFile = $this->getConfigFile()) {
             $this->loadConfigFile($configFile);
+        }
+
+        if (!$this->configFile && $localConfig = $this->getLocalConfigFile()) {
+            $this->loadConfigFile($localConfig);
         }
     }
 
@@ -140,13 +147,30 @@ class Configuration
         foreach ($this->getConfigDirs() as $dir) {
             $file = $dir . '/config.php';
             if (@is_file($file)) {
-                return $this->configFile = $file;
+                return $file;
             }
 
             $file = $dir . '/rc.php';
             if (@is_file($file)) {
-                return $this->configFile = $file;
+                return $file;
             }
+        }
+    }
+
+    /**
+     * Get the local PsySH config file.
+     *
+     * Searches for a project specific config file `.psysh.php` in the current
+     * working directory.
+     *
+     * @return string
+     */
+    public function getLocalConfigFile()
+    {
+        $localConfig = getenv('PWD') . '/.psysh.php';
+
+        if (@is_file($localConfig)) {
+            return $localConfig;
         }
     }
 

--- a/src/Psy/functions.php
+++ b/src/Psy/functions.php
@@ -34,6 +34,7 @@ if (!function_exists('Psy\info')) {
             'error logging level' => $config->errorLoggingLevel(),
             'config file'         => array(
                 'default config file' => $config->getConfigFile(),
+                'local config file'   => $config->getLocalConfigFile(),
                 'PSYSH_CONFIG env'    => getenv('PSYSH_CONFIG'),
             ),
             // 'config dir'  => $config->getConfigDir(),

--- a/test/Psy/Test/ConfigurationTest.php
+++ b/test/Psy/Test/ConfigurationTest.php
@@ -132,6 +132,26 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(E_ALL & ~E_NOTICE, $config->errorLoggingLevel());
     }
 
+    public function testLoadLocalConfigFile()
+    {
+        $oldPwd = getenv('PWD');
+        putenv('PWD=' . realpath(__DIR__ . '/../../fixtures/project/'));
+
+        $config = new Configuration();
+
+        // When no configuration file is specified local project config is merged
+        $this->assertFalse($config->useReadline());
+        $this->assertTrue($config->usePcntl());
+
+        $config = new Configuration(array('configFile' => __DIR__ . '/../../fixtures/config.php'));
+
+        // Defining a configuration file skips loading local project config
+        $this->assertTrue($config->useReadline());
+        $this->assertFalse($config->usePcntl());
+
+        putenv("PWD=$oldPwd");
+    }
+
     /**
      * @expectedException PHPUnit_Framework_Error_Deprecated
      */

--- a/test/fixtures/project/.psysh.php
+++ b/test/fixtures/project/.psysh.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of Psy Shell
+ *
+ * (c) 2015 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    'useReadline' => false,
+    'usePcntl'    => true,
+);


### PR DESCRIPTION
Allows creating `.psysh.php` file that will overload global configuration on a per-project basis.

cc @ameech