### PR TITLE
Switched to PSR4 for autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     },
     "autoload": {
         "files": ["src/Psy/functions.php"],
-        "psr-0": {
-            "Psy\\": "src/"
+        "psr-4": {
+            "Psy\\": "src/Psy/"
         }
     },
     "bin": ["bin/psysh"],


### PR DESCRIPTION
PSR0 is deprecated, and we can move to PSR4 without moving any files about.