### PR TITLE
Make 'exit;' behave the same as the exit command

### DIFF
--- a/src/Psy/CodeCleaner.php
+++ b/src/Psy/CodeCleaner.php
@@ -18,6 +18,7 @@ use Psy\CodeCleaner\AbstractClassPass;
 use Psy\CodeCleaner\AssignThisVariablePass;
 use Psy\CodeCleaner\CalledClassPass;
 use Psy\CodeCleaner\CallTimePassByReferencePass;
+use Psy\CodeCleaner\ExitPass;
 use Psy\CodeCleaner\FunctionReturnInWriteContextPass;
 use Psy\CodeCleaner\ImplicitReturnPass;
 use Psy\CodeCleaner\InstanceOfPass;
@@ -90,6 +91,7 @@ class CodeCleaner
             new ValidClassNamePass(),
             new ValidConstantPass(),
             new MagicConstantsPass(),
+            new ExitPass(),
         );
     }
 

--- a/src/Psy/CodeCleaner/ExitPass.php
+++ b/src/Psy/CodeCleaner/ExitPass.php
@@ -12,12 +12,11 @@
 namespace Psy\CodeCleaner;
 
 use PhpParser\Node;
-use Psy\Exception\BreakException;
 use PhpParser\Node\Expr\Exit_;
+use Psy\Exception\BreakException;
 
 class ExitPass extends CodeCleanerPass
 {
-
     /**
      * Throws a PsySH BreakException instead on exit().
      *
@@ -25,7 +24,8 @@ class ExitPass extends CodeCleanerPass
      *
      * @param \PhpParser\Node $node
      */
-    public function enterNode(Node $node) {
+    public function enterNode(Node $node)
+    {
         if ($node instanceof Exit_) {
             throw new BreakException('Goodbye.');
         }

--- a/src/Psy/CodeCleaner/ExitPass.php
+++ b/src/Psy/CodeCleaner/ExitPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2015 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\CodeCleaner;
+
+use PhpParser\Node;
+use Psy\Exception\BreakException;
+use PhpParser\Node\Expr\Exit_;
+
+class ExitPass extends CodeCleanerPass
+{
+
+    /**
+     * Throws a PsySH BreakException instead on exit().
+     *
+     * @throws \Psy\Exception\BreakException if the node is an exit node.
+     *
+     * @param \PhpParser\Node $node
+     */
+    public function enterNode(Node $node) {
+        if ($node instanceof Exit_) {
+            throw new BreakException('Goodbye.');
+        }
+    }
+}

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2015 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\CodeCleaner;
+
+use PhpParser\NodeTraverser;
+use Psy\CodeCleaner\ExitPass;
+
+class ExitPassTest extends CodeCleanerTestCase
+{
+    public function setUp()
+    {
+        $this->pass      = new ExitPass();
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this->pass);
+    }
+
+    /**
+     * @expectedException \Psy\Exception\BreakException
+     */
+    public function testExitStatement()
+    {
+        $stmts = $this->parse('exit;');
+        $this->traverser->traverse($stmts);
+    }
+
+}
+

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -31,6 +31,4 @@ class ExitPassTest extends CodeCleanerTestCase
         $stmts = $this->parse('exit;');
         $this->traverser->traverse($stmts);
     }
-
 }
-


### PR DESCRIPTION
Add an ExitPass so `exit;` behaves the same as the exit command.

This should be helping us soon in the drush psysh integration (we have problems with the database connection being closed before the drush command has finished, when the shell exits).