### PR TITLE
Only default commands get autocompletion

### DIFF
--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -859,7 +859,8 @@ class Shell extends Application
         }
     }
 
-    protected function initializeTabCompletion() {
+    protected function initializeTabCompletion()
+    {
         // auto completer needs shell to be linked to configuration because of the context aware matchers
         if ($this->config->getTabCompletion()) {
             $this->completion = $this->config->getAutoCompleter();
@@ -873,5 +874,4 @@ class Shell extends Application
             $this->completion->activate();
         }
     }
-
 }

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -859,6 +859,12 @@ class Shell extends Application
         }
     }
 
+    /**
+     * Initialize tab completion matchers.
+     *
+     * If tab completion is enabled this adds tab completion matchers to the
+     * auto completer and sets context if needed.
+     */
     protected function initializeTabCompletion()
     {
         // auto completer needs shell to be linked to configuration because of the context aware matchers

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -78,20 +78,6 @@ class Shell extends Application
         $this->readline = $this->config->getReadline();
 
         parent::__construct('Psy Shell', self::VERSION);
-
-        $this->config->setShell($this);
-        // auto completer needs shell to be linked to configuration because of the context aware matchers
-        if ($this->config->getTabCompletion()) {
-            $this->completion = $this->config->getAutoCompleter();
-            $this->addTabCompletionMatchers($this->config->getTabCompletionMatchers());
-            foreach ($this->getTabCompletionMatchers() as $matcher) {
-                if ($matcher instanceof ContextAware) {
-                    $matcher->setContext($this->context);
-                }
-                $this->completion->addMatcher($matcher);
-            }
-            $this->completion->activate();
-        }
     }
 
     /**
@@ -271,6 +257,8 @@ class Shell extends Application
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
+        $this->initializeTabCompletion();
+
         if ($input === null && !isset($_SERVER['argv'])) {
             $input = new ArgvInput(array());
         }
@@ -870,4 +858,20 @@ class Shell extends Application
             return $this->getScopeVariableNames();
         }
     }
+
+    protected function initializeTabCompletion() {
+        // auto completer needs shell to be linked to configuration because of the context aware matchers
+        if ($this->config->getTabCompletion()) {
+            $this->completion = $this->config->getAutoCompleter();
+            $this->addTabCompletionMatchers($this->config->getTabCompletionMatchers());
+            foreach ($this->getTabCompletionMatchers() as $matcher) {
+                if ($matcher instanceof ContextAware) {
+                    $matcher->setContext($this->context);
+                }
+                $this->completion->addMatcher($matcher);
+            }
+            $this->completion->activate();
+        }
+    }
+
 }


### PR DESCRIPTION
Now that we have drush commands inside PsySH in drush (which is awesome!) one small problem is that the autocompletion does not work for any of these commands.

I looked into it further; Only the default commands will get this autocompletion as tab completion is initialized in the Shell constructor. So anything using addCommands, like we are, is too late. The CommandsMatcher instance has already been created with $this->all() - which at the time is only the default commands.

This just moves the tab completion code into an initializeTabCompletion method, which then gets called in Shell::run instead. This means everything added before the shell is run will be included.

Not sure if this is the best way to fix this problem? Certainly seems like the simplest and least invasive approach maybe. Also confirmed this fixes the completion of added commands. Thoughts?