### PR TITLE
Feature proposal: add configurable `forceColor` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ return array(
     //
     // This will default to true in a future release, but is false for now.
     'warnOnMultipleConfigs' => true,
+
+    // When set to true, forces output to contain ANSI colors, even in non-interactive
+    // (non-tty) shells, where it may not be supported.
+    'forceColor' => false,
 );
 ```
 

--- a/src/Psy/Command/ShowCommand.php
+++ b/src/Psy/Command/ShowCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShowCommand extends ReflectingCommand
 {
+    private $forceColor;
+
     /**
      * {@inheritdoc}
      */
@@ -54,10 +56,30 @@ HELP
         list($value, $reflector) = $this->getTargetAndReflector($input->getArgument('value'));
 
         try {
-            $output->page(CodeFormatter::format($reflector), ShellOutput::OUTPUT_RAW);
+            $output->page(CodeFormatter::format($reflector, $this->forceColor()), ShellOutput::OUTPUT_RAW);
         } catch (RuntimeException $e) {
             $output->writeln(SignatureFormatter::format($reflector));
             throw $e;
         }
+    }
+
+    /**
+     * Sets whether or not to force colors in output.
+     *
+     * @param bool $forceColor
+     */
+    public function setForceColor($forceColor)
+    {
+        $this->forceColor = $forceColor;
+    }
+
+    /**
+     * Returns whether or not to force colors in output.
+     *
+     * @return bool
+     */
+    public function forceColor()
+    {
+        return $this->forceColor;
     }
 }

--- a/src/Psy/Command/WhereamiCommand.php
+++ b/src/Psy/Command/WhereamiCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class WhereamiCommand extends Command
 {
+    private $forceColor;
+
     public function __construct()
     {
         if (version_compare(PHP_VERSION, '5.3.6', '>=')) {
@@ -108,8 +110,29 @@ HELP
         $num = $input->getOption('num');
         $colors = new ConsoleColor();
         $colors->addTheme('line_number', array('blue'));
+        $colors->setForceStyle($this->forceColor());
         $highlighter = new Highlighter($colors);
         $contents = file_get_contents($info['file']);
         $output->page($highlighter->getCodeSnippet($contents, $info['line'], $num, $num), ShellOutput::OUTPUT_RAW);
+    }
+
+    /**
+     * Sets whether or not to force colors in output.
+     *
+     * @param bool $forceColor
+     */
+    public function setForceColor($forceColor)
+    {
+        $this->forceColor = $forceColor;
+    }
+
+    /**
+     * Returns whether or not to force colors in output.
+     *
+     * @return bool
+     */
+    public function forceColor()
+    {
+        return $this->forceColor;
     }
 }

--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -34,7 +34,7 @@ class Configuration
         'defaultIncludes', 'useReadline', 'usePcntl', 'codeCleaner', 'pager',
         'loop', 'configDir', 'dataDir', 'runtimeDir', 'manualDbFile',
         'requireSemicolons', 'historySize', 'eraseDuplicates', 'tabCompletion',
-        'errorLoggingLevel', 'warnOnMultipleConfigs',
+        'errorLoggingLevel', 'warnOnMultipleConfigs', 'forceColor'
     );
 
     private $defaultIncludes;
@@ -56,6 +56,7 @@ class Configuration
     private $tabCompletionMatchers = array();
     private $errorLoggingLevel = E_ALL;
     private $warnOnMultipleConfigs = false;
+    private $forceColor = false;
 
     // services
     private $readline;
@@ -701,10 +702,28 @@ class Configuration
     public function getOutput()
     {
         if (!isset($this->output)) {
-            $this->output = new ShellOutput(ShellOutput::VERBOSITY_NORMAL, null, null, $this->getPager());
+            $this->output = new ShellOutput(
+                ShellOutput::VERBOSITY_NORMAL,
+                $this->getOutputDecorated(),
+                null,
+                $this->getPager()
+            );
         }
 
         return $this->output;
+    }
+
+    /**
+     * If color is not forced, returns `null` so "auto-guessing"
+     * (http://git.io/vEe9u) is used.
+     *
+     * If color is forced, returns `true` to always decorate output.
+     *
+     * @return null|true
+     */
+    public function getOutputDecorated()
+    {
+        return $this->forceColor() ? true : null;
     }
 
     /**
@@ -979,5 +998,26 @@ class Configuration
     public function warnOnMultipleConfigs()
     {
         return $this->warnOnMultipleConfigs;
+    }
+
+    /**
+     * When set to `true`, forces output to contain ANSI colors, even in
+     * non-interactive (non-tty) shells, where it may not be supported.
+     *
+     * @param bool $forceColor
+     */
+    public function setForceColor($forceColor)
+    {
+        $this->forceColor = (bool) $forceColor;
+    }
+
+    /**
+     * Returns whether or not to force colors in output.
+     *
+     * @return bool
+     */
+    public function forceColor()
+    {
+        return $this->forceColor;
     }
 }

--- a/src/Psy/Formatter/CodeFormatter.php
+++ b/src/Psy/Formatter/CodeFormatter.php
@@ -24,10 +24,11 @@ class CodeFormatter implements Formatter
      * Format the code represented by $reflector.
      *
      * @param \Reflector $reflector
+     * @param bool $forceColor (default: false)
      *
      * @return string formatted code
      */
-    public static function format(\Reflector $reflector)
+    public static function format(\Reflector $reflector, $forceColor = false)
     {
         if ($fileName = $reflector->getFileName()) {
             if (!is_file($fileName)) {
@@ -40,6 +41,7 @@ class CodeFormatter implements Formatter
 
             $colors = new ConsoleColor();
             $colors->addTheme('line_number', array('blue'));
+            $colors->setForceStyle($forceColor);
             $highlighter = new Highlighter($colors);
 
             return $highlighter->getCodeSnippet($file, $start, 0, $end);

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -199,6 +199,12 @@ class Shell extends Application
      */
     protected function getDefaultCommands()
     {
+        $show = new Command\ShowCommand();
+        $show->setForceColor($this->config->forceColor());
+
+        $whereami = new Command\WhereamiCommand();
+        $whereami->setForceColor($this->config->forceColor());
+
         $hist = new Command\HistoryCommand();
         $hist->setReadline($this->readline);
 
@@ -207,9 +213,9 @@ class Shell extends Application
             new Command\ListCommand(),
             new Command\DumpCommand(),
             new Command\DocCommand(),
-            new Command\ShowCommand(),
+            $show,
             new Command\WtfCommand(),
-            new Command\WhereamiCommand(),
+            $whereami,
             new Command\ThrowUpCommand(),
             new Command\TraceCommand(),
             new Command\BufferCommand(),

--- a/test/Psy/Test/Command/ShowCommandTest.php
+++ b/test/Psy/Test/Command/ShowCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2015 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\Command;
+
+use Psy\Command\ShowCommand;
+
+class ShowCommandTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function forceColorProvider()
+    {
+        return [
+            'false' => [false, false],
+            'true' => [true, true],
+        ];
+    }
+
+    /**
+     * @dataProvider forceColorProvider
+     */
+    public function testForceColor($expectation, $forceColor)
+    {
+        $command = new ShowCommand();
+        $command->setForceColor($forceColor);
+
+        $this->assertSame($expectation, $command->forceColor());
+    }
+}

--- a/test/Psy/Test/Command/WhereamiCommandTest.php
+++ b/test/Psy/Test/Command/WhereamiCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2015 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\Command;
+
+use Psy\Command\WhereamiCommand;
+
+class WhereamiCommandTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function forceColorProvider()
+    {
+        return [
+            'false' => [false, false],
+            'true' => [true, true],
+        ];
+    }
+
+    /**
+     * @dataProvider forceColorProvider
+     */
+    public function testForceColor($expectation, $forceColor)
+    {
+        $command = new WhereamiCommand();
+        $command->setForceColor($forceColor);
+
+        $this->assertSame($expectation, $command->forceColor());
+    }
+}

--- a/test/Psy/Test/ConfigurationTest.php
+++ b/test/Psy/Test/ConfigurationTest.php
@@ -28,6 +28,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(function_exists('pcntl_signal'), $config->hasPcntl());
         $this->assertEquals(function_exists('pcntl_signal'), $config->usePcntl());
         $this->assertFalse($config->requireSemicolons());
+        $this->assertFalse($config->forceColor());
     }
 
     public function testGettersAndSetters()
@@ -100,6 +101,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'loop'              => $loop,
             'requireSemicolons' => true,
             'errorLoggingLevel' => E_ERROR | E_WARNING,
+            'forceColor'        => true
         ));
 
         $this->assertFalse($config->useReadline());
@@ -109,6 +111,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($loop, $config->getLoop());
         $this->assertTrue($config->requireSemicolons());
         $this->assertEquals(E_ERROR | E_WARNING, $config->errorLoggingLevel());
+        $this->assertTrue($config->forceColor());
     }
 
     public function testLoadConfigFile()
@@ -169,5 +172,32 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $includes = $config->getDefaultIncludes();
         $this->assertCount(1, $includes);
         $this->assertEquals('/file.php', $includes[0]);
+    }
+
+    public function testGetOutput()
+    {
+        $config = new Configuration();
+        $output = $config->getOutput();
+
+        $this->assertInstanceOf('\Psy\Output\ShellOutput', $output);
+    }
+
+    public function getOutputDecoratedProvider()
+    {
+        return [
+            'color not forced (use "auto-guessing")' => [null, false],
+            'color forced (always decorate)' => [true, true],
+        ];
+    }
+
+    /**
+     * @dataProvider getOutputDecoratedProvider
+     */
+    public function testGetOutputDecorated($expectation, $force_color)
+    {
+        $config = new Configuration();
+        $config->setForceColor($force_color);
+
+        $this->assertSame($expectation, $config->getOutputDecorated());
     }
 }


### PR DESCRIPTION
When `true`, forces output to contain ANSI colors, even in non-interactive (non-tty) shells, where it may not be supported.

This may be a solution for the participants in #78. Thanks for looking!