### PR TITLE
Prevent PHP's built-in web server from hanging

### DIFF
--- a/src/Psy/ExecutionLoop/ForkingLoop.php
+++ b/src/Psy/ExecutionLoop/ForkingLoop.php
@@ -82,7 +82,7 @@ class ForkingLoop extends Loop
         fwrite($up, $this->serializeReturn($shell->getScopeVariables()));
         fclose($up);
 
-        exit;
+        posix_kill(posix_getpid(), SIGKILL);
     }
 
     /**


### PR DESCRIPTION
This should fix the issue in #67. `pcntl_fork` doesn't work well with PHP's built-in web server. I believe this has to do with the `exit` call in the child cleaning up resources its parent still needs.

**Caveat**: When running this patch under PHP 5.6.26 with `tabCompletion => true` a segfault occurs on the second request to the server during the call to `readline_completion_function` in `Psy\TabCompletion\AutoCompleter::activate`. This issue appears fixed in PHP 7.