### PR TITLE
Feature proposal: Add startup message to Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ return array(
     //
     // To disable update checks entirely, set to 'never'.
     'updateCheck' => 'daily',
+
+    // Display an additional startup message. Default is ''.
+    // You can color and style the message thanks to the Symfony Console tags.
+    // See https://symfony.com/doc/current/console/coloring.html for more details.
+    'startupMessage' => sprintf('<info>%s</info>', shell_exec('uptime')),
 );
 ```
 

--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -44,7 +44,7 @@ class Configuration
         'loop', 'configDir', 'dataDir', 'runtimeDir', 'manualDbFile',
         'requireSemicolons', 'useUnicode', 'historySize', 'eraseDuplicates',
         'tabCompletion', 'errorLoggingLevel', 'warnOnMultipleConfigs',
-        'colorMode', 'updateCheck',
+        'colorMode', 'updateCheck', 'startupMessage',
     );
 
     private $defaultIncludes;
@@ -69,6 +69,7 @@ class Configuration
     private $warnOnMultipleConfigs = false;
     private $colorMode;
     private $updateCheck;
+    private $startupMessage;
 
     // services
     private $readline;
@@ -1172,5 +1173,25 @@ class Configuration
         }
 
         return $dir . '/update_check.json';
+    }
+
+    /**
+     * Set the startup message.
+     *
+     * @param string $message
+     */
+    public function setStartupMessage($message)
+    {
+        $this->startupMessage = $message;
+    }
+
+    /**
+     * Get the startup message.
+     *
+     * @return string|null
+     */
+    public function getStartupMessage()
+    {
+        return $this->startupMessage;
     }
 }

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -304,6 +304,7 @@ class Shell extends Application
 
         $this->output->writeln($this->getHeader());
         $this->writeVersionInfo();
+        $this->writeStartupMessage();
 
         try {
             $this->loop->run($this);
@@ -936,6 +937,17 @@ class Shell extends Application
             }
         } catch (\InvalidArgumentException $e) {
             $this->output->writeln($e->getMessage());
+        }
+    }
+
+    /**
+     * Write a startup message if set.
+     */
+    protected function writeStartupMessage()
+    {
+        $message = $this->config->getStartupMessage();
+        if ($message !== null && $message !== '') {
+            $this->output->writeln($message);
         }
     }
 }

--- a/test/Psy/Test/ConfigurationTest.php
+++ b/test/Psy/Test/ConfigurationTest.php
@@ -30,6 +30,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(function_exists('pcntl_signal'), $config->usePcntl());
         $this->assertFalse($config->requireSemicolons());
         $this->assertSame(Configuration::COLOR_MODE_AUTO, $config->colorMode());
+        $this->assertNull($config->getStartupMessage());
     }
 
     public function testGettersAndSetters()
@@ -103,6 +104,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'requireSemicolons' => true,
             'errorLoggingLevel' => E_ERROR | E_WARNING,
             'colorMode'         => Configuration::COLOR_MODE_FORCED,
+            'startupMessage'    => 'Psysh is awesome!',
         ));
 
         $this->assertFalse($config->useReadline());
@@ -113,6 +115,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($config->requireSemicolons());
         $this->assertEquals(E_ERROR | E_WARNING, $config->errorLoggingLevel());
         $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode());
+        $this->assertSame('Psysh is awesome!', $config->getStartupMessage());
     }
 
     public function testLoadConfigFile()


### PR DESCRIPTION
Hi.
First of all, let me thank you for such a great package!
It helps my everyday development very much!

This PR adds a startup message to Configuration.
 I often use the `scope variables` for less typing (just like alias) so I would like to display its descriptions and something at startup.

For example:
```php
<?php

require __DIR__ . '/vendor/autoload.php';

$message = <<<'EOM'
                  ___           _           _
  /\/\  _   _    / _ \_ __ ___ (_) ___  ___| |_
 /    \| | | |  / /_)/ '__/ _ \| |/ _ \/ __| __|
/ /\/\ \ |_| | / ___/| | | (_) | |  __/ (__| |_
\/    \/\__, | \/    |_|  \___// |\___|\___|\__|
        |___/                |__/

<fg=yellow>%s</>
Variable functions:
  <info>$user(int $id)</info> Find a single user by id
  <info>$begin()</info>       Begin a transaction
  <info>$commit()</info>      Commit a transaction
EOM;

$shell = new Psy\Shell(new Psy\Configuration([
    'startupMessage' => sprintf($message, shell_exec('uptime'))
]));
$shell->setScopeVariables([
    'user' =>  function ($id) {
        return App\User::find($id);
    },
    'begin' => function () {
        return DB::beginTransaction();
    },
    'commit' => function () {
        return DB::commit();
    },
]);
$shell->run();
```

will show:
```sh
$ php sh.php
Psy Shell v0.8.1 (PHP 5.5.34 — cli) by Justin Hileman
                  ___           _           _
  /\/\  _   _    / _ \_ __ ___ (_) ___  ___| |_
 /    \| | | |  / /_)/ '__/ _ \| |/ _ \/ __| __|
/ /\/\ \ |_| | / ___/| | | (_) | |  __/ (__| |_
\/    \/\__, | \/    |_|  \___// |\___|\___|\__|
        |___/                |__/

 2:11  up 27 days, 11:56, 2 users, load averages: 2.10 2.41 2.45

Variable functions:
  $user(int $id) Find a single user by id
  $begin()       Begin a transaction
  $commit()      Commit a transaction
>>>
```

If `startupMessage` is not set, it only displays the version message (just the same as it is).

I hope you like it. :)