### PR TITLE
Allow running in the global scope

### DIFF
--- a/src/Psy/Context.php
+++ b/src/Psy/Context.php
@@ -21,6 +21,7 @@ class Context
 {
     private static $specialVars = array('_', '_e', '__psysh__', 'this');
     private $scopeVariables = array();
+    private $useGlobalScope = false;
     private $lastException;
     private $returnValue;
     private $boundObject;
@@ -82,6 +83,26 @@ class Context
         }
 
         return $vars;
+    }
+
+    /**
+     * Use the global scope.
+     *
+     * @param bool $use
+     */
+    public function setGlobalScope($use)
+    {
+        $this->useGlobalScope = $use;
+    }
+
+    /**
+     * Whether to use the global scope.
+     *
+     * @return bool
+     */
+    public function getGlobalScope()
+    {
+        return $this->useGlobalScope;
     }
 
     /**

--- a/src/Psy/ExecutionLoop/Loop.php
+++ b/src/Psy/ExecutionLoop/Loop.php
@@ -47,6 +47,11 @@ class Loop
      */
     public function run(Shell $shell)
     {
+        /**
+         * @param Shell $__psysh__
+         *
+         * @throws ThrowUpException
+         */
         $loop = function ($__psysh__) {
             // Load user-defined includes
             set_error_handler(array($__psysh__, 'handleError'));
@@ -60,11 +65,21 @@ class Loop
             restore_error_handler();
             unset($__psysh_include__);
 
-            extract($__psysh__->getScopeVariables(false));
+            if ($__psysh__->getGlobalScope()) {
+                extract($GLOBALS, EXTR_OVERWRITE | EXTR_REFS);
+            } else {
+                extract($__psysh__->getScopeVariables(false));
+            }
 
             do {
                 $__psysh__->beforeLoop();
-                $__psysh__->setScopeVariables(get_defined_vars());
+                if ($__psysh__->getGlobalScope()) {
+                    foreach (array_diff_key($GLOBALS, get_defined_vars()) as $__key__ => $__val__) {
+                        $GLOBALS[$__key__] = &$$__key__;
+                    }
+                } else {
+                    $__psysh__->setScopeVariables(get_defined_vars());
+                }
 
                 try {
                     // read a line, see if we should eval

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -382,6 +382,26 @@ class Shell extends Application
     }
 
     /**
+     * Use the global scope.
+     *
+     * @param bool $use
+     */
+    public function setGlobalScope($use)
+    {
+        $this->context->setGlobalScope($use);
+    }
+
+    /**
+     * Whether to use the global scope.
+     *
+     * @return bool
+     */
+    public function getGlobalScope()
+    {
+        return $this->context->getGlobalScope();
+    }
+
+    /**
      * Set the variables currently in scope.
      *
      * @param array $vars


### PR DESCRIPTION
Add Shell/Context option to use the global scope. When set, ignore scope variables and copy (by reference) `$GLOBALS` into the scope.
    
Fixes #353.

This is moderately horrible; I don't think there is a non-horrible way of doing it though.