### PR TITLE
Set magic variables in all the reflection commands

### DIFF
--- a/src/Psy/Command/DocCommand.php
+++ b/src/Psy/Command/DocCommand.php
@@ -79,6 +79,9 @@ HELP
                 $output->writeln($doc);
             }
         });
+
+        // Set some magic local variables
+        $this->setCommandScopeVariables($reflector);
     }
 
     private function getManualDoc($reflector)

--- a/src/Psy/Command/DumpCommand.php
+++ b/src/Psy/Command/DumpCommand.php
@@ -72,6 +72,10 @@ HELP
         $depth  = $input->getOption('depth');
         $target = $this->resolveTarget($input->getArgument('target'));
         $output->page($this->presenter->present($target, $depth, $input->getOption('all') ? Presenter::VERBOSE : 0));
+
+        if (is_object($target)) {
+            $this->setCommandScopeVariables(new \ReflectionObject($target));
+        }
     }
 
     /**

--- a/src/Psy/Command/ListCommand.php
+++ b/src/Psy/Command/ListCommand.php
@@ -133,6 +133,11 @@ HELP
         if ($input->getOption('long')) {
             $output->stopPaging();
         }
+
+        // Set some magic local variables
+        if ($reflector !== null) {
+            $this->setCommandScopeVariables($reflector);
+        }
     }
 
     /**

--- a/src/Psy/Command/ListCommand/VariableEnumerator.php
+++ b/src/Psy/Command/ListCommand/VariableEnumerator.php
@@ -20,7 +20,11 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 class VariableEnumerator extends Enumerator
 {
-    private static $specialVars = array('_', '_e');
+    // n.b. this array is the order in which special variables will be listed
+    private static $specialNames = array(
+        '_', '_e', '__function', '__method', '__class', '__namespace', '__file', '__line', '__dir',
+    );
+
     private $context;
 
     /**
@@ -76,23 +80,28 @@ class VariableEnumerator extends Enumerator
     {
         $scopeVars = $this->context->getAll();
         uksort($scopeVars, function ($a, $b) {
-            if ($a === '_e') {
+            $aIndex = array_search($a, self::$specialNames);
+            $bIndex = array_search($b, self::$specialNames);
+
+            if ($aIndex !== false) {
+                if ($bIndex !== false) {
+                    return $aIndex - $bIndex;
+                }
+
                 return 1;
-            } elseif ($b === '_e') {
-                return -1;
-            } elseif ($a === '_') {
-                return 1;
-            } elseif ($b === '_') {
-                return -1;
-            } else {
-                // TODO: this should be natcasesort
-                return strcasecmp($a, $b);
             }
+
+            if ($bIndex !== false) {
+                return -1;
+            }
+
+            // TODO: this should be natcasesort
+            return strcasecmp($a, $b);
         });
 
         $ret = array();
         foreach ($scopeVars as $name => $val) {
-            if (!$showAll && in_array($name, self::$specialVars)) {
+            if (!$showAll && in_array($name, self::$specialNames)) {
                 continue;
             }
 
@@ -118,7 +127,7 @@ class VariableEnumerator extends Enumerator
                 $fname = '$' . $name;
                 $ret[$fname] = array(
                     'name'  => $fname,
-                    'style' => in_array($name, self::$specialVars) ? self::IS_PRIVATE : self::IS_PUBLIC,
+                    'style' => in_array($name, self::$specialNames) ? self::IS_PRIVATE : self::IS_PUBLIC,
                     'value' => $this->presentRef($val), // TODO: add types to variable signatures
                 );
             }

--- a/src/Psy/Command/ShowCommand.php
+++ b/src/Psy/Command/ShowCommand.php
@@ -66,6 +66,9 @@ HELP
     {
         list($value, $reflector) = $this->getTargetAndReflector($input->getArgument('value'));
 
+        // Set some magic local variables
+        $this->setCommandScopeVariables($reflector);
+
         try {
             $output->page(CodeFormatter::format($reflector, $this->colorMode), ShellOutput::OUTPUT_RAW);
         } catch (RuntimeException $e) {

--- a/src/Psy/Context.php
+++ b/src/Psy/Context.php
@@ -19,8 +19,16 @@ namespace Psy;
  */
 class Context
 {
-    private static $specialVars = array('_', '_e', '__psysh__', 'this');
+    private static $specialNames = array('_', '_e', '__psysh__', 'this');
+
+    // Whitelist a very limited number of command-scope magic variable names.
+    // This might be a bad idea, but future me can sort it out.
+    private static $commandScopeNames = array(
+        '__function', '__method', '__class', '__namespace', '__file', '__line', '__dir',
+    );
+
     private $scopeVariables = array();
+    private $commandScopeVariables = array();
     private $lastException;
     private $returnValue;
     private $boundObject;
@@ -41,26 +49,37 @@ class Context
                 return $this->returnValue;
 
             case '_e':
-                if (!isset($this->lastException)) {
-                    throw new \InvalidArgumentException('Unknown variable: $' . $name);
+                if (isset($this->lastException)) {
+                    return $this->lastException;
                 }
-
-                return $this->lastException;
+                break;
 
             case 'this':
-                if (!isset($this->boundObject)) {
-                    throw new \InvalidArgumentException('Unknown variable: $' . $name);
+                if (isset($this->boundObject)) {
+                    return $this->boundObject;
                 }
+                break;
 
-                return $this->boundObject;
+            case '__function':
+            case '__method':
+            case '__class':
+            case '__namespace':
+            case '__file':
+            case '__line':
+            case '__dir':
+                if (array_key_exists($name, $this->commandScopeVariables)) {
+                    return $this->commandScopeVariables[$name];
+                }
+                break;
 
             default:
-                if (!array_key_exists($name, $this->scopeVariables)) {
-                    throw new \InvalidArgumentException('Unknown variable: $' . $name);
+                if (array_key_exists($name, $this->scopeVariables)) {
+                    return $this->scopeVariables[$name];
                 }
-
-                return $this->scopeVariables[$name];
+                break;
         }
+
+        throw new \InvalidArgumentException('Unknown variable: $' . $name);
     }
 
     /**
@@ -70,8 +89,19 @@ class Context
      */
     public function getAll()
     {
-        $vars = $this->scopeVariables;
-        $vars['_'] = $this->returnValue;
+        return array_merge($this->scopeVariables, $this->getSpecialVariables());
+    }
+
+    /**
+     * Get all defined magic variables: $_, $_e, $__class, $__file, etc.
+     *
+     * @return array
+     */
+    public function getSpecialVariables()
+    {
+        $vars = array(
+            '_' => $this->returnValue,
+        );
 
         if (isset($this->lastException)) {
             $vars['_e'] = $this->lastException;
@@ -81,19 +111,23 @@ class Context
             $vars['this'] = $this->boundObject;
         }
 
-        return $vars;
+        return array_merge($vars, $this->commandScopeVariables);
     }
 
     /**
      * Set all scope variables.
      *
-     * This method does *not* set the magic $_ and $_e variables.
+     * This method does *not* set any of the magic variables: $_, $_e, $__class, $__file, etc.
      *
      * @param array $vars
      */
     public function setAll(array $vars)
     {
-        foreach (self::$specialVars as $key) {
+        foreach (self::$specialNames as $key) {
+            unset($vars[$key]);
+        }
+
+        foreach (self::$commandScopeNames as $key) {
             unset($vars[$key]);
         }
 
@@ -164,5 +198,58 @@ class Context
     public function getBoundObject()
     {
         return $this->boundObject;
+    }
+
+    /**
+     * Set command-scope magic variables: $__class, $__file, etc.
+     *
+     * @param array $commandScopeVariables
+     */
+    public function setCommandScopeVariables(array $commandScopeVariables)
+    {
+        $vars = array();
+        foreach ($commandScopeVariables as $key => $value) {
+            // kind of type check
+            if (is_scalar($value) && in_array($key, self::$commandScopeNames)) {
+                $vars[$key] = $value;
+            }
+        }
+
+        $this->commandScopeVariables = $vars;
+    }
+
+    /**
+     * Get command-scope magic variables: $__class, $__file, etc.
+     *
+     * @return array
+     */
+    public function getCommandScopeVariables()
+    {
+        return $this->commandScopeVariables;
+    }
+
+    /**
+     * Get unused command-scope magic variables names: __class, __file, etc.
+     *
+     * This is used by the shell to unset old command-scope variables after a
+     * new batch is set.
+     *
+     * @return array Array of unused variable names
+     */
+    public function getUnusedCommandScopeVariableNames()
+    {
+        return array_diff(self::$commandScopeNames, array_keys($this->commandScopeVariables));
+    }
+
+    /**
+     * Check whether a variable name is a magic variable.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public static function isSpecialVariableName($name)
+    {
+        return in_array($name, self::$specialNames) || in_array($name, self::$commandScopeNames);
     }
 }

--- a/src/Psy/ExecutionLoop/ForkingLoop.php
+++ b/src/Psy/ExecutionLoop/ForkingLoop.php
@@ -11,6 +11,7 @@
 
 namespace Psy\ExecutionLoop;
 
+use Psy\Context;
 use Psy\Shell;
 
 /**
@@ -152,11 +153,11 @@ class ForkingLoop extends Loop
 
         foreach ($return as $key => $value) {
             // No need to return magic variables
-            if ($key === '_' || $key === '_e') {
+            if (Context::isSpecialVariableName($key)) {
                 continue;
             }
 
-            // Resources don't error, but they don't serialize well either.
+            // Resources and Closures don't error, but they don't serialize well either.
             if (is_resource($value) || $value instanceof \Closure) {
                 continue;
             }

--- a/src/Psy/ExecutionLoop/Loop.php
+++ b/src/Psy/ExecutionLoop/Loop.php
@@ -76,6 +76,16 @@ class Loop
                         version_compare(PHP_VERSION, '5.4', '>=') ? 1 : 2
                     );
 
+                    // Let PsySH inject some magic variables back into the
+                    // shell scope... things like $__class, and $__file set by
+                    // reflection commands
+                    extract($__psysh__->getSpecialScopeVariables(false));
+
+                    // And unset any magic variables which are no longer needed
+                    foreach ($__psysh__->getUnusedCommandScopeVariableNames() as $__psysh_var_name__) {
+                        unset($$__psysh_var_name__, $__psysh_var_name__);
+                    }
+
                     set_error_handler(array($__psysh__, 'handleError'));
                     $_ = eval($__psysh__->flushCode() ?: Loop::NOOP_INPUT);
                     restore_error_handler();

--- a/src/Psy/Formatter/CodeFormatter.php
+++ b/src/Psy/Formatter/CodeFormatter.php
@@ -31,7 +31,15 @@ class CodeFormatter implements Formatter
      */
     public static function format(\Reflector $reflector, $colorMode = null)
     {
+        if (!self::isReflectable($reflector)) {
+            throw new RuntimeException('Source code unavailable.');
+        }
+
         $colorMode = $colorMode ?: Configuration::COLOR_MODE_AUTO;
+
+        if ($reflector instanceof \ReflectionGenerator) {
+            $reflector = $reflector->getFunction();
+        }
 
         if ($fileName = $reflector->getFileName()) {
             if (!is_file($fileName)) {
@@ -47,12 +55,22 @@ class CodeFormatter implements Formatter
             $highlighter = new Highlighter($colors);
 
             return $highlighter->getCodeSnippet($file, $start, 0, $end);
-
-            // no need to escape this bad boy, since (for now) it's being output raw.
-            // return OutputFormatter::escape(implode(PHP_EOL, $code));
-            return implode(PHP_EOL, $code);
         } else {
             throw new RuntimeException('Source code unavailable.');
         }
+    }
+
+    /**
+     * Check whether a Reflector instance is reflectable by this formatter.
+     *
+     * @param \Reflector $reflector
+     *
+     * @return bool
+     */
+    private static function isReflectable(\Reflector $reflector)
+    {
+        return $reflector instanceof \ReflectionClass ||
+            $reflector instanceof \ReflectionFunctionAbstract ||
+            $reflector instanceof \ReflectionGenerator;
     }
 }

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -416,6 +416,36 @@ class Shell extends Application
     }
 
     /**
+     * Return the set of magic variables currently in scope.
+     *
+     * @param bool $includeBoundObject Pass false to exclude 'this'. If you're
+     *                                 passing the scope variables to `extract`
+     *                                 in PHP 7.1+, you _must_ exclude 'this'
+     *
+     * @return array Associative array of magic scope variables
+     */
+    public function getSpecialScopeVariables($includeBoundObject = true)
+    {
+        $vars = $this->context->getSpecialVariables();
+
+        if (!$includeBoundObject) {
+            unset($vars['this']);
+        }
+
+        return $vars;
+    }
+
+    /**
+     * Get the set of unused command-scope variable names.
+     *
+     * @return array Array of unused variable names
+     */
+    public function getUnusedCommandScopeVariableNames()
+    {
+        return $this->context->getUnusedCommandScopeVariableNames();
+    }
+
+    /**
      * Get the set of variable names currently in scope.
      *
      * @return array Array of variable names


### PR DESCRIPTION
`doc`, `dump`, `list` and `show` all set magic variables, as appropriate:

* `$__function`
* `$__method`
* `$__class`
* `$__namespace`
* `$__file`
* `$__line`
* `$__dir`

… so you can use 'em in code to do things like this:

```
>>> show Psy\sh
>>> file_get_contents($__file);
```