### PR TITLE
Catch PHP7 \Errors in ForkingLoop::serializeReturn()

### DIFF
--- a/src/Psy/ExecutionLoop/ForkingLoop.php
+++ b/src/Psy/ExecutionLoop/ForkingLoop.php
@@ -166,8 +166,7 @@ class ForkingLoop extends Loop
                 $serializable[$key] = $value;
             } catch (\Exception $e) {
                 // we'll just ignore this one...
-            }
-            catch (\Error $e) {
+            } catch (\Error $e) {
                 // and this one too...
             }
         }

--- a/src/Psy/ExecutionLoop/ForkingLoop.php
+++ b/src/Psy/ExecutionLoop/ForkingLoop.php
@@ -166,7 +166,7 @@ class ForkingLoop extends Loop
                 $serializable[$key] = $value;
             } catch (\Exception $e) {
                 // we'll just ignore this one...
-            } catch (\Error $e) {
+            } catch (\Throwable $e) {
                 // and this one too...
             }
         }

--- a/src/Psy/ExecutionLoop/ForkingLoop.php
+++ b/src/Psy/ExecutionLoop/ForkingLoop.php
@@ -167,6 +167,9 @@ class ForkingLoop extends Loop
             } catch (\Exception $e) {
                 // we'll just ignore this one...
             }
+            catch (\Error $e) {
+                // and this one too...
+            }
         }
 
         return @serialize($serializable);


### PR DESCRIPTION
In Drush we have this problem https://github.com/drush-ops/drush/pull/2635 . If/when the Drupal container gets serialized and assertions are enabled, we get an `AssertionError` but these are not caught as they extend `Error` (and implement `Throwable`).

Does it makes sense to add this here instead? When testing it seems to make no difference when using PHP5.6 as it should always get the `Exception` first anyway.