### PR TITLE
Better VarDumper escaping.

### DIFF
--- a/src/Psy/VarDumper/Dumper.php
+++ b/src/Psy/VarDumper/Dumper.php
@@ -22,7 +22,8 @@ class Dumper extends CliDumper
 {
     private $formatter;
 
-    protected static $controlCharsRx = '/[\x00-\x1F\x7F]+/';
+    protected static $onlyControlCharsRx = '/^[\x00-\x1F\x7F]+$/';
+    protected static $controlCharsRx = '/([\x00-\x1F\x7F]+)/';
     protected static $controlCharsMap = array(
         "\0"   => '\0',
         "\t"   => '\t',
@@ -67,22 +68,29 @@ class Dumper extends CliDumper
             $value = strtr($value, '@', '#');
         }
 
+        $styled = '';
         $map = self::$controlCharsMap;
         $cchr = $this->styles['cchr'];
-        $value = preg_replace_callback(self::$controlCharsRx, function ($c) use ($map, $cchr) {
-            $s = '';
-            $i = 0;
-            $c = $c[0];
-            do {
-                $s .= isset($map[$c[$i]]) ? $map[$c[$i]] : sprintf('\x%02X', ord($c[$i]));
-            } while (isset($c[++$i]));
 
-            return "<{$cchr}>{$s}</{$cchr}>";
-        }, $this->formatter->escape($value));
+        $chunks = preg_split(self::$controlCharsRx, $value, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        foreach ($chunks as $chunk) {
+            if (preg_match(self::$onlyControlCharsRx, $chunk)) {
+                $chars = '';
+                $i = 0;
+                do {
+                    $chars .= isset($map[$chunk[$i]]) ? $map[$chunk[$i]] : sprintf('\x%02X', ord($chunk[$i]));
+                } while (isset($chunk[++$i]));
+
+                $chars = $this->formatter->escape($chars);
+                $styled .= "<{$cchr}>{$chars}</{$cchr}>";
+            } else {
+                $styled .= $this->formatter->escape($chunk);
+            }
+        }
 
         $style = $this->styles[$style];
 
-        return "<{$style}>{$value}</{$style}>";
+        return "<{$style}>{$styled}</{$style}>";
     }
 
     /**


### PR DESCRIPTION
In the current implementation, strings with a literal backslash which are immediately followed by a control character get formatted as:

    \<cchr>\n</cchr>

… which actually escapes the opening tag for cchr. And this screws up Symfony's `OutputFormatter`. Forever, apparently.

cc @nicolas-grekas

Fixes #352