### PR TITLE
Support `xxxxx or die` syntax

### DIFF
--- a/src/Psy/CodeCleaner/ExitPass.php
+++ b/src/Psy/CodeCleaner/ExitPass.php
@@ -12,12 +12,9 @@
 namespace Psy\CodeCleaner;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Exit_;
-use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified as FullyQualifiedName;
-use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt\Throw_;
 
 class ExitPass extends CodeCleanerPass
 {
@@ -29,9 +26,7 @@ class ExitPass extends CodeCleanerPass
     public function leaveNode(Node $node)
     {
         if ($node instanceof Exit_) {
-            $args = array(new Arg(new String_('Goodbye.')));
-
-            return new Throw_(new New_(new FullyQualifiedName('Psy\Exception\BreakException'), $args));
+            return new StaticCall(new FullyQualifiedName('Psy\Exception\BreakException'), 'exit_');
         }
     }
 }

--- a/src/Psy/Exception/BreakException.php
+++ b/src/Psy/Exception/BreakException.php
@@ -36,4 +36,16 @@ class BreakException extends \Exception implements Exception
     {
         return $this->rawMessage;
     }
+
+    /**
+     * Throws BreakException.
+     *
+     * Since `throw` can not be inserted into arbitrary expressions, it wraps with function call.
+     *
+     * @throws BreakException
+     */
+    public static function exit_()
+    {
+        throw new self('Goodbye');
+    }
 }

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -18,7 +18,7 @@ class ExitPassTest extends CodeCleanerTestCase
     /**
      * @var string
      */
-    private $expectedExceptionString = "throw new \\Psy\\Exception\\BreakException('Goodbye.');";
+    private $expectedExceptionString = "\\Psy\\Exception\\BreakException::exit_();";
 
     public function setUp()
     {

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -18,7 +18,7 @@ class ExitPassTest extends CodeCleanerTestCase
     /**
      * @var string
      */
-    private $expectedExceptionString = "\\Psy\\Exception\\BreakException::exit_();";
+    private $expectedExceptionString = "\\Psy\\Exception\\BreakException::exit_()";
 
     public function setUp()
     {
@@ -41,11 +41,15 @@ class ExitPassTest extends CodeCleanerTestCase
     public function dataProviderExitStatement()
     {
         return array(
-            array('exit;', $this->expectedExceptionString),
-            array('exit();', $this->expectedExceptionString),
-            array('die;', $this->expectedExceptionString),
-            array('if (true) { exit; }', "if (true) {\n    $this->expectedExceptionString\n}"),
-            array('if (false) { exit; }', "if (false) {\n    $this->expectedExceptionString\n}"),
+            array('exit;', "{$this->expectedExceptionString};"),
+            array('exit();', "{$this->expectedExceptionString};"),
+            array('die;', "{$this->expectedExceptionString};"),
+            array('exit(die(die));', "{$this->expectedExceptionString};"),
+            array('if (true) { exit; }', "if (true) {\n    {$this->expectedExceptionString};\n}"),
+            array('if (false) { exit; }', "if (false) {\n    {$this->expectedExceptionString};\n}"),
+            array('1 and exit();', "1 and {$this->expectedExceptionString};"),
+            array('foo() or die', "foo() or {$this->expectedExceptionString};"),
+            array('exit and 1;', "{$this->expectedExceptionString} and 1;"),
         );
     }
 }

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -18,7 +18,7 @@ class ExitPassTest extends CodeCleanerTestCase
     /**
      * @var string
      */
-    private $expectedExceptionString = "\\Psy\\Exception\\BreakException::exit_()";
+    private $expectedExceptionString = '\\Psy\\Exception\\BreakException::exit_()';
 
     public function setUp()
     {
@@ -50,6 +50,10 @@ class ExitPassTest extends CodeCleanerTestCase
             array('1 and exit();', "1 and {$this->expectedExceptionString};"),
             array('foo() or die', "foo() or {$this->expectedExceptionString};"),
             array('exit and 1;', "{$this->expectedExceptionString} and 1;"),
+            array('if (exit) { echo "wat"; }', "if ({$this->expectedExceptionString}) {\n    echo \"wat\";\n}"),
+            array('exit or die;', "{$this->expectedExceptionString} or {$this->expectedExceptionString};"),
+            array('switch (die) { }', "switch ({$this->expectedExceptionString}) {\n}"),
+            array('for ($i = 1; $i < 10; die) {}', "for (\$i = 1; \$i < 10; {$this->expectedExceptionString}) {\n}"),
         );
     }
 }

--- a/test/Psy/Test/CodeCleaner/ExitPassTest.php
+++ b/test/Psy/Test/CodeCleaner/ExitPassTest.php
@@ -50,7 +50,7 @@ class ExitPassTest extends CodeCleanerTestCase
             array('1 and exit();', "1 and {$this->expectedExceptionString};"),
             array('foo() or die', "foo() or {$this->expectedExceptionString};"),
             array('exit and 1;', "{$this->expectedExceptionString} and 1;"),
-            array('if (exit) { echo "wat"; }', "if ({$this->expectedExceptionString}) {\n    echo \"wat\";\n}"),
+            array('if (exit) { echo $wat; }', "if ({$this->expectedExceptionString}) {\n    echo \$wat;\n}"),
             array('exit or die;', "{$this->expectedExceptionString} or {$this->expectedExceptionString};"),
             array('switch (die) { }', "switch ({$this->expectedExceptionString}) {\n}"),
             array('for ($i = 1; $i < 10; die) {}', "for (\$i = 1; \$i < 10; {$this->expectedExceptionString}) {\n}"),


### PR DESCRIPTION
`foo() or die(1);` and `$f = function () { 1 or die; };` are valid statements, but it is not accepted by PsySH.
Because `foo or throw new Exception()` is not a valid statement.

```
PHP error:  syntax error, unexpected throw (T_THROW) on line 2
```

This constraint can be avoided by a trick that combines Closure and `call_user_func`.