### PR TITLE
Timer command for function time profiling

### DIFF
--- a/src/Psy/Command/TimeitCommand.php
+++ b/src/Psy/Command/TimeitCommand.php
@@ -3,10 +3,11 @@
 namespace Psy\Command;
 
 use Psy\Configuration;
+use Psy\Input\CodeArgument;
 use Psy\Shell;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 
 /**
  * Class TimeitCommand
@@ -22,7 +23,7 @@ class TimeitCommand extends Command
         $this
             ->setName('timeit')
             ->setDefinition(array(
-                new InputArgument('target', InputArgument::REQUIRED, 'A target object or primitive to profile.', null),
+                new CodeArgument('code', InputArgument::REQUIRED, 'Code to execute.'),
             ))
             ->setDescription('Profiles with a timer.')
             ->setHelp(
@@ -40,16 +41,16 @@ HELP
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $target = $input->getArgument('target');
-        $start = microtime(true);
+        $code = $input->getArgument('code');
 
         /** @var Shell $shell */
         $shell = $this->getApplication();
         $sh = new Shell(new Configuration());
         $sh->setOutput($output);
         $sh->setScopeVariables($shell->getScopeVariables());
-        $sh->execute($target);
 
+        $start = microtime(true);
+        $sh->execute($code);
         $end = microtime(true);
 
         $output->writeln(sprintf('<info>Command took %.6f seconds to complete.</info>', $end-$start));

--- a/src/Psy/Command/TimeitCommand.php
+++ b/src/Psy/Command/TimeitCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Psy\Command;
+
+use Psy\Configuration;
+use Psy\Shell;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Class TimeitCommand
+ * @package Psy\Command
+ */
+class TimeitCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('timeit')
+            ->setDefinition(array(
+                new InputArgument('target', InputArgument::REQUIRED, 'A target object or primitive to profile.', null),
+            ))
+            ->setDescription('Profiles with a timer.')
+            ->setHelp(
+                <<<HELP
+Time profiling for functions and commands.
+
+e.g.
+<return>>>> timeit \$closure()</return>
+HELP
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $target = $input->getArgument('target');
+        $start = microtime(true);
+
+        /** @var Shell $shell */
+        $shell = $this->getApplication();
+        $sh = new Shell(new Configuration());
+        $sh->setOutput($output);
+        $sh->setScopeVariables($shell->getScopeVariables());
+        $sh->execute($target);
+
+        $end = microtime(true);
+
+        $output->writeln(sprintf('<info>Command took %.6f seconds to complete.</info>', $end-$start));
+    }
+}

--- a/src/Psy/Command/TimeitCommand.php
+++ b/src/Psy/Command/TimeitCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2017 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Psy\Command;
 
 use Psy\Configuration;
@@ -10,8 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class TimeitCommand
- * @package Psy\Command
+ * Class TimeitCommand.
  */
 class TimeitCommand extends Command
 {
@@ -27,11 +35,11 @@ class TimeitCommand extends Command
             ))
             ->setDescription('Profiles with a timer.')
             ->setHelp(
-                <<<HELP
+                <<<'HELP'
 Time profiling for functions and commands.
 
 e.g.
-<return>>>> timeit \$closure()</return>
+<return>>>> timeit $closure()</return>
 HELP
             );
     }
@@ -53,6 +61,6 @@ HELP
         $sh->execute($code);
         $end = microtime(true);
 
-        $output->writeln(sprintf('<info>Command took %.6f seconds to complete.</info>', $end-$start));
+        $output->writeln(sprintf('<info>Command took %.6f seconds to complete.</info>', $end - $start));
     }
 }

--- a/src/Psy/Shell.php
+++ b/src/Psy/Shell.php
@@ -188,6 +188,7 @@ class Shell extends Application
             new Command\WtfCommand($this->config->colorMode()),
             new Command\WhereamiCommand($this->config->colorMode()),
             new Command\ThrowUpCommand(),
+            new Command\TimeitCommand(),
             new Command\TraceCommand(),
             new Command\BufferCommand(),
             new Command\ClearCommand(),


### PR DESCRIPTION
Extracted from @Markcial's #138. Rebased and updated to work with the latest 0.9.x-dev stuff. Uses the new code argument input type (like `sudo` does).

Depends on #375 and #379.