### PR TITLE
Fixed slow composer performance on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - php: hhvm
     - php: hhvm-nightly
 
-install: travis_retry composer update --no-interaction --prefer-source
+install: travis_retry composer update --no-interaction
 
 script: vendor/bin/phpunit
 


### PR DESCRIPTION
This no-longer counts towards API rate limits, so is fine.