### PR TITLE
Enable verbose mode on PHPUnit on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 install: travis_retry composer update --no-interaction
 
-script: vendor/bin/phpunit
+script: vendor/bin/phpunit --verbose
 
 before_deploy: bin/package -v $TRAVIS_TAG
 


### PR DESCRIPTION
This means that the details of the tests skipped are printed.