### PR TITLE
Add CodeCleaner\FunctionContextPass

### DIFF
--- a/src/Psy/CodeCleaner.php
+++ b/src/Psy/CodeCleaner.php
@@ -20,6 +20,7 @@ use Psy\CodeCleaner\CalledClassPass;
 use Psy\CodeCleaner\CallTimePassByReferencePass;
 use Psy\CodeCleaner\ExitPass;
 use Psy\CodeCleaner\FinalClassPass;
+use Psy\CodeCleaner\FunctionContextPass;
 use Psy\CodeCleaner\FunctionReturnInWriteContextPass;
 use Psy\CodeCleaner\ImplicitReturnPass;
 use Psy\CodeCleaner\InstanceOfPass;
@@ -87,6 +88,7 @@ class CodeCleaner
             new PassableByReferencePass(),
             new CalledClassPass(),
             new FinalClassPass(),
+            new FunctionContextPass(),
             new InstanceOfPass(),
             new LeavePsyshAlonePass(),
             new LegacyEmptyPass(),

--- a/src/Psy/CodeCleaner/FunctionContextPass.php
+++ b/src/Psy/CodeCleaner/FunctionContextPass.php
@@ -50,8 +50,6 @@ class FunctionContextPass extends CodeCleanerPass
     }
 
     /**
-     * Converts exit calls to BreakExceptions.
-     *
      * @param \PhpParser\Node $node
      */
     public function leaveNode(Node $node)

--- a/src/Psy/CodeCleaner/FunctionContextPass.php
+++ b/src/Psy/CodeCleaner/FunctionContextPass.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2017 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\CodeCleaner;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\Goto_;
+use PhpParser\Node\Stmt\Label;
+use Psy\Exception\FatalErrorException;
+
+class FunctionContextPass extends CodeCleanerPass
+{
+    /** @var int */
+    private $functionDepth;
+
+    /**
+     * @param array $nodes
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->functionDepth = 0;
+    }
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof FunctionLike) {
+            $this->functionDepth++;
+
+            return;
+        }
+
+        // node is inside function context
+        if ($this->functionDepth !== 0) {
+            return;
+        }
+
+        // It causes fatal error.
+        if ($node instanceof Yield_) {
+            $msg = 'The "yield" expression can only be used inside a function';
+            throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
+        }
+
+        // These statements are meaningless to interactive shell.
+        // PsySH does not have facilities for these statements.
+        if ($node instanceof Goto_) {
+            $msg = 'Can not goto label in PsySH top level.';
+            throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
+        } elseif ($node instanceof Label) {
+            $msg = 'Can not declare label in PsySH top level.';
+            throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
+        }
+    }
+
+    /**
+     * Converts exit calls to BreakExceptions.
+     *
+     * @param \PhpParser\Node $node
+     */
+    public function leaveNode(Node $node)
+    {
+        if ($node instanceof FunctionLike) {
+            $this->functionDepth--;
+        }
+    }
+}

--- a/src/Psy/CodeCleaner/FunctionContextPass.php
+++ b/src/Psy/CodeCleaner/FunctionContextPass.php
@@ -14,8 +14,6 @@ namespace Psy\CodeCleaner;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\Goto_;
-use PhpParser\Node\Stmt\Label;
 use Psy\Exception\FatalErrorException;
 
 class FunctionContextPass extends CodeCleanerPass
@@ -47,16 +45,6 @@ class FunctionContextPass extends CodeCleanerPass
         // It causes fatal error.
         if ($node instanceof Yield_) {
             $msg = 'The "yield" expression can only be used inside a function';
-            throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
-        }
-
-        // These statements are meaningless to interactive shell.
-        // PsySH does not have facilities for these statements.
-        if ($node instanceof Goto_) {
-            $msg = 'Can not goto label in PsySH top level.';
-            throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
-        } elseif ($node instanceof Label) {
-            $msg = 'Can not declare label in PsySH top level.';
             throw new FatalErrorException($msg, 0, E_ERROR, null, $node->getLine());
         }
     }

--- a/test/Psy/Test/CodeCleaner/FunctionContextPassTest.php
+++ b/test/Psy/Test/CodeCleaner/FunctionContextPassTest.php
@@ -24,25 +24,6 @@ class FunctionContextPassTest extends CodeCleanerTestCase
     }
 
     /**
-     * @dataProvider invalidStatements
-     * @expectedException \Psy\Exception\FatalErrorException
-     */
-    public function testProcessStatementFails($code)
-    {
-        $stmts = $this->parse($code);
-        $this->traverser->traverse($stmts);
-    }
-
-    public function invalidStatements()
-    {
-        return array(
-            array('label:'),
-            array('label: echo "foo"'),
-            array('goto unknown;'),
-        );
-    }
-
-    /**
      * @dataProvider validStatements
      */
     public function testProcessStatementPasses($code)
@@ -56,7 +37,6 @@ class FunctionContextPassTest extends CodeCleanerTestCase
         return array(
             array('function foo() { yield; }'),
             array('if (function(){ yield; })'),
-            array('function(){ $i = 0; begin: $i++; echo $i; goto begin;};'),
         );
     }
 

--- a/test/Psy/Test/CodeCleaner/FunctionContextPassTest.php
+++ b/test/Psy/Test/CodeCleaner/FunctionContextPassTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2017 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\CodeCleaner;
+
+use PhpParser\NodeTraverser;
+use Psy\CodeCleaner\FunctionContextPass;
+
+class FunctionContextPassTest extends CodeCleanerTestCase
+{
+    public function setUp()
+    {
+        $this->pass      = new FunctionContextPass();
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this->pass);
+    }
+
+    /**
+     * @dataProvider invalidStatements
+     * @expectedException \Psy\Exception\FatalErrorException
+     */
+    public function testProcessStatementFails($code)
+    {
+        $stmts = $this->parse($code);
+        $this->traverser->traverse($stmts);
+    }
+
+    public function invalidStatements()
+    {
+        return array(
+            array('label:'),
+            array('label: echo "foo"'),
+            array('goto unknown;'),
+        );
+    }
+
+    /**
+     * @dataProvider validStatements
+     */
+    public function testProcessStatementPasses($code)
+    {
+        $stmts = $this->parse($code);
+        $this->traverser->traverse($stmts);
+    }
+
+    public function validStatements()
+    {
+        return array(
+            array('function foo() { yield; }'),
+            array('if (function(){ yield; })'),
+            array('function(){ $i = 0; begin: $i++; echo $i; goto begin;};'),
+        );
+    }
+
+    /**
+     * @dataProvider invalidYieldStatements
+     * @expectedException \Psy\Exception\FatalErrorException
+     */
+    public function testInvalidYield($code)
+    {
+        if (version_compare(PHP_VERSION, '5.4', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $stmts = $this->parse($code);
+        $this->traverser->traverse($stmts);
+    }
+
+    public function invalidYieldStatements()
+    {
+        return array(
+            array('yield'),
+            array('if (yield)'),
+        );
+    }
+}


### PR DESCRIPTION
Fix #394

This Pass handles `yield`, `:` (label declaration) and `goto` statement outside function context.

## Before

<img width="1467" alt="2017-07-08 6 38 20" src="https://user-images.githubusercontent.com/822086/27977970-1f7a4900-63a8-11e7-94c3-d92ecf6e4c3e.png">

## After

<img width="828" alt="2017-07-08 6 39 07" src="https://user-images.githubusercontent.com/822086/27977990-31c47450-63a8-11e7-94db-6260c7af73f0.png">
