### PR TITLE
Updated PHP reference manual download url

### DIFF
--- a/src/Psy/Command/DocCommand.php
+++ b/src/Psy/Command/DocCommand.php
@@ -74,7 +74,7 @@ HELP
             if (empty($doc) && !$db) {
                 $output->writeln('<warning>PHP manual not found</warning>');
                 $output->writeln('    To document core PHP functionality, download the PHP reference manual:');
-                $output->writeln('    https://github.com/bobthecow/dotfiles/wiki/PHP-manual');
+                $output->writeln('    https://github.com/bobthecow/psysh/wiki/PHP-manual');
             } else {
                 $output->writeln($doc);
             }


### PR DESCRIPTION
The current URL for the docs download points to a GitHub 404 page.

<img width="825" alt="screen shot 2017-07-23 at 1 23 31 pm" src="https://user-images.githubusercontent.com/24803032/28496269-e95f2bb0-6faa-11e7-994f-53fd16ff3a78.png">

I've updated to point to the current location: https://github.com/bobthecow/psysh/wiki/Installation