### PR TITLE
Be able to force indexes to be shown, also for numeric arrays

### DIFF
--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -47,6 +47,7 @@ class Configuration
         'defaultIncludes',
         'eraseDuplicates',
         'errorLoggingLevel',
+        'forceArrayIndexes',
         'historySize',
         'loop',
         'manualDbFile',
@@ -89,6 +90,7 @@ class Configuration
     private $colorMode;
     private $updateCheck;
     private $startupMessage;
+    private $forceArrayIndexes = false;
 
     // services
     private $readline;
@@ -1074,7 +1076,7 @@ class Configuration
     public function getPresenter()
     {
         if (!isset($this->presenter)) {
-            $this->presenter = new Presenter($this->getOutput()->getFormatter());
+            $this->presenter = new Presenter($this->getOutput()->getFormatter(), $this->getForceArrayIndexes());
         }
 
         return $this->presenter;
@@ -1272,5 +1274,25 @@ class Configuration
     public function getPrompt()
     {
         return $this->prompt;
+    }
+
+    /**
+     * Get the force array indexes.
+     *
+     * @return bool
+     */
+    public function getForceArrayIndexes()
+    {
+        return $this->forceArrayIndexes;
+    }
+
+    /**
+     * Set the force array indexes.
+     *
+     * @param bool $forceArrayIndexes
+     */
+    public function setForceArrayIndexes($forceArrayIndexes)
+    {
+        $this->forceArrayIndexes = $forceArrayIndexes;
     }
 }

--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -1076,7 +1076,7 @@ class Configuration
     public function getPresenter()
     {
         if (!isset($this->presenter)) {
-            $this->presenter = new Presenter($this->getOutput()->getFormatter(), $this->getForceArrayIndexes());
+            $this->presenter = new Presenter($this->getOutput()->getFormatter(), $this->forceArrayIndexes());
         }
 
         return $this->presenter;
@@ -1281,7 +1281,7 @@ class Configuration
      *
      * @return bool
      */
-    public function getForceArrayIndexes()
+    public function forceArrayIndexes()
     {
         return $this->forceArrayIndexes;
     }

--- a/src/Psy/VarDumper/Dumper.php
+++ b/src/Psy/VarDumper/Dumper.php
@@ -21,6 +21,7 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 class Dumper extends CliDumper
 {
     private $formatter;
+    private $forceArrayIndexes;
 
     protected static $onlyControlCharsRx = '/^[\x00-\x1F\x7F]+$/';
     protected static $controlCharsRx = '/([\x00-\x1F\x7F]+)/';
@@ -34,9 +35,10 @@ class Dumper extends CliDumper
         "\033" => '\e',
     );
 
-    public function __construct(OutputFormatter $formatter)
+    public function __construct(OutputFormatter $formatter, $forceArrayIndexes = false)
     {
         $this->formatter = $formatter;
+        $this->forceArrayIndexes = $forceArrayIndexes;
         parent::__construct();
         $this->setColors(false);
     }
@@ -57,7 +59,7 @@ class Dumper extends CliDumper
      */
     protected function dumpKey(Cursor $cursor)
     {
-        if (Cursor::HASH_INDEXED !== $cursor->hashType) {
+        if ($this->forceArrayIndexes || Cursor::HASH_INDEXED !== $cursor->hashType) {
             parent::dumpKey($cursor);
         }
     }

--- a/src/Psy/VarDumper/Presenter.php
+++ b/src/Psy/VarDumper/Presenter.php
@@ -46,13 +46,13 @@ class Presenter
         'index'     => 'number',
     );
 
-    public function __construct(OutputFormatter $formatter)
+    public function __construct(OutputFormatter $formatter, $forceArrayIndexes = false)
     {
         // Work around https://github.com/symfony/symfony/issues/23572
         $oldLocale = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, 'C');
 
-        $this->dumper = new Dumper($formatter);
+        $this->dumper = new Dumper($formatter, $forceArrayIndexes);
         $this->dumper->setStyles($this->styles);
 
         // Now put the locale back


### PR DESCRIPTION
We use psysh a lot with numerically indexed arrays, where we would love to be able to see a value with it's corrosponding index number.

I dislike having to pass the value two layers deep, if you have any better way in mind, please let me know.