### PR TITLE
Do not autocomplete if only whitespace precedes cursor

### DIFF
--- a/src/Psy/TabCompletion/AutoCompleter.php
+++ b/src/Psy/TabCompletion/AutoCompleter.php
@@ -45,12 +45,12 @@ class AutoCompleter
      * Handle readline completion.
      *
      * @param string $input Readline current word
-     * @param int    $index Current word index
-     * @param array  $info  readline_info() data
-     *
+     * @param int $start Readline start match
+     * @param int $end Readline end match
+     * @param array $info readline_info() data
      * @return array
      */
-    public function processCallback($input, $index, $info = array())
+    public function processCallback($input, $start, $end, $info = array())
     {
         // Some (Windows?) systems provide incomplete `readline_info`, so let's
         // try to work around it.
@@ -60,6 +60,10 @@ class AutoCompleter
         }
         if ($line === '' && $input !== '') {
             $line = $input;
+        }
+
+        if ($this->shouldInsertOnlyTab($line, $start, $end)) {
+            return ["\t"];
         }
 
         $tokens = token_get_all('<?php ' . $line);
@@ -82,18 +86,32 @@ class AutoCompleter
     }
 
     /**
+     * @param string $line Readline current line
+     * @param int $start The start of the readline input
+     * @param int $end The end of the readline input
+     * @return bool true if the characters before $index are only whitespace
+     * @internal param int $index Current word index
+     */
+    private function shouldInsertOnlyTab($line, $start, $end)
+    {
+        $precedingInput = substr($line, $start, $end-$start);
+
+        return empty(trim($precedingInput));
+    }
+
+    /**
      * The readline_completion_function callback handler.
      *
      * @see processCallback
      *
-     * @param $input
-     * @param $index
-     *
+     * @param string $input
+     * @param int $start
+     * @param int $end
      * @return array
      */
-    public function callback($input, $index)
+    public function callback($input, $start, $end)
     {
-        return $this->processCallback($input, $index, readline_info());
+        return $this->processCallback($input, $start, $end, readline_info());
     }
 
     /**

--- a/src/Psy/TabCompletion/AutoCompleter.php
+++ b/src/Psy/TabCompletion/AutoCompleter.php
@@ -45,13 +45,12 @@ class AutoCompleter
      * Handle readline completion.
      *
      * @param string $input Readline current word
-     * @param int    $start Readline start match
-     * @param int    $end   Readline end match
+     * @param int    $index Current word index
      * @param array  $info  readline_info() data
      *
      * @return array
      */
-    public function processCallback($input, $start, $end, $info = array())
+    public function processCallback($input, $index, $info = array())
     {
         // Some (Windows?) systems provide incomplete `readline_info`, so let's
         // try to work around it.
@@ -63,7 +62,7 @@ class AutoCompleter
             $line = $input;
         }
 
-        if ($this->shouldInsertOnlyTab($line, $start, $end)) {
+        if ($this->shouldInsertOnlyTab($line, $info['point'])) {
             return array("\t");
         }
 
@@ -88,20 +87,19 @@ class AutoCompleter
 
     /**
      * @param string $line  Readline current line
-     * @param int    $start The start of the readline input
-     * @param int    $end   The end of the readline input
+     * @param int    $point The cursor position on the line
      *
-     * @return bool true if the characters before $index are only whitespace
+     * @return bool true if the characters before $point are only whitespace
      *
      * @internal param int $index Current word index
      */
-    private function shouldInsertOnlyTab($line, $start, $end)
+    private function shouldInsertOnlyTab($line, $point)
     {
-        $precedingInput = substr($line, 0, $end);
+        $precedingInput = substr($line, 0, $point);
 
         $trimmedInput = trim($precedingInput);
 
-        return empty($trimmedInput);
+        return $trimmedInput === '';
     }
 
     /**
@@ -110,14 +108,13 @@ class AutoCompleter
      * @see processCallback
      *
      * @param string $input
-     * @param int    $start
-     * @param int    $end
+     * @param int    $index
      *
      * @return array
      */
-    public function callback($input, $start, $end)
+    public function callback($input, $index)
     {
-        return $this->processCallback($input, $start, $end, readline_info());
+        return $this->processCallback($input, $index, readline_info());
     }
 
     /**

--- a/src/Psy/TabCompletion/AutoCompleter.php
+++ b/src/Psy/TabCompletion/AutoCompleter.php
@@ -94,7 +94,7 @@ class AutoCompleter
      */
     private function shouldInsertOnlyTab($line, $start, $end)
     {
-        $precedingInput = substr($line, $start, $end-$start);
+        $precedingInput = substr($line, 0, $end);
 
         return empty(trim($precedingInput));
     }

--- a/src/Psy/TabCompletion/AutoCompleter.php
+++ b/src/Psy/TabCompletion/AutoCompleter.php
@@ -45,9 +45,10 @@ class AutoCompleter
      * Handle readline completion.
      *
      * @param string $input Readline current word
-     * @param int $start Readline start match
-     * @param int $end Readline end match
-     * @param array $info readline_info() data
+     * @param int    $start Readline start match
+     * @param int    $end   Readline end match
+     * @param array  $info  readline_info() data
+     *
      * @return array
      */
     public function processCallback($input, $start, $end, $info = array())
@@ -63,7 +64,7 @@ class AutoCompleter
         }
 
         if ($this->shouldInsertOnlyTab($line, $start, $end)) {
-            return ["\t"];
+            return array("\t");
         }
 
         $tokens = token_get_all('<?php ' . $line);
@@ -86,10 +87,12 @@ class AutoCompleter
     }
 
     /**
-     * @param string $line Readline current line
-     * @param int $start The start of the readline input
-     * @param int $end The end of the readline input
+     * @param string $line  Readline current line
+     * @param int    $start The start of the readline input
+     * @param int    $end   The end of the readline input
+     *
      * @return bool true if the characters before $index are only whitespace
+     *
      * @internal param int $index Current word index
      */
     private function shouldInsertOnlyTab($line, $start, $end)
@@ -105,8 +108,9 @@ class AutoCompleter
      * @see processCallback
      *
      * @param string $input
-     * @param int $start
-     * @param int $end
+     * @param int    $start
+     * @param int    $end
+     *
      * @return array
      */
     public function callback($input, $start, $end)

--- a/src/Psy/TabCompletion/AutoCompleter.php
+++ b/src/Psy/TabCompletion/AutoCompleter.php
@@ -99,7 +99,9 @@ class AutoCompleter
     {
         $precedingInput = substr($line, 0, $end);
 
-        return empty(trim($precedingInput));
+        $trimmedInput = trim($precedingInput);
+
+        return empty($trimmedInput);
     }
 
     /**

--- a/test/Psy/Test/TabCompletion/AutoCompleterTest.php
+++ b/test/Psy/Test/TabCompletion/AutoCompleterTest.php
@@ -59,7 +59,7 @@ class AutoCompleterTest extends \PHPUnit_Framework_TestCase
 
         $context->setAll(array('foo' => 12, 'bar' => new \DOMDocument()));
 
-        $code = $tabCompletion->processCallback('', 0, array(
+        $code = $tabCompletion->processCallback('', 0, strlen($line), array(
            'line_buffer' => $line,
            'point'       => 0,
            'end'         => strlen($line),

--- a/test/Psy/Test/TabCompletion/AutoCompleterTest.php
+++ b/test/Psy/Test/TabCompletion/AutoCompleterTest.php
@@ -59,7 +59,7 @@ class AutoCompleterTest extends \PHPUnit_Framework_TestCase
 
         $context->setAll(array('foo' => 12, 'bar' => new \DOMDocument()));
 
-        $code = $tabCompletion->processCallback('', 0, strlen($line), array(
+        $code = $tabCompletion->processCallback('', 0, array(
            'line_buffer' => $line,
            'point'       => 0,
            'end'         => strlen($line),

--- a/test/Psy/Test/TabCompletion/AutoCompleterTest.php
+++ b/test/Psy/Test/TabCompletion/AutoCompleterTest.php
@@ -61,7 +61,8 @@ class AutoCompleterTest extends \PHPUnit_Framework_TestCase
 
         $code = $tabCompletion->processCallback('', 0, array(
            'line_buffer' => $line,
-           'point'       => 0,
+           'start'       => 0,
+           'point'       => strlen($line),
            'end'         => strlen($line),
         ));
 


### PR DESCRIPTION
If we are on the first character of a line and the input buffer is empty, return a tab character when autocompleting.

This should fix https://github.com/bobthecow/psysh/issues/254