### PR TITLE
Autocomplete class/object: Error handling

### DIFF
--- a/src/Psy/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -36,7 +36,12 @@ class ClassAttributesMatcher extends AbstractMatcher
 
         $class = $this->getNamespaceAndClass($tokens);
 
-        $reflection = new \ReflectionClass($class);
+        try {
+            $reflection = new \ReflectionClass($class);
+        } catch (\ReflectionException $re) {
+            return array();
+        }
+
         $vars = array_merge(
             array_map(
                 function ($var) {

--- a/src/Psy/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -36,7 +36,12 @@ class ClassMethodsMatcher extends AbstractMatcher
 
         $class = $this->getNamespaceAndClass($tokens);
 
-        $reflection = new \ReflectionClass($class);
+        try {
+            $reflection = new \ReflectionClass($class);
+        } catch (\ReflectionException $re) {
+            return array();
+        }
+
         $methods = $reflection->getMethods(\ReflectionMethod::IS_STATIC);
         $methods = array_map(function (\ReflectionMethod $method) {
             return $method->getName();

--- a/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -47,6 +47,10 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
             return array();
         }
 
+        if (!is_object($object)) {
+            return array();
+        }
+
         return array_filter(
             array_keys(get_class_vars(get_class($object))),
             function ($var) use ($input) {

--- a/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/Psy/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -47,6 +47,10 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
             return array();
         }
 
+        if (!is_object($object)) {
+            return array();
+        }
+
         return array_filter(
             get_class_methods($object),
             function ($var) use ($input) {


### PR DESCRIPTION
Adds some extra checks and safeguards to prevent various completion-related errors from popping up:

Objects:
```
>>> $no = [];
>>> $no-><tab> // gives an error
```

Classes are basically the same deal, except it'd be the double colon operator and the errors take a bit to pop up (various incarnations of "this class does not exist")