### PR TITLE
Add support for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/console": "~2.3.10|^2.4.2|~3.0",
-        "symfony/var-dumper": "~2.7|~3.0",
+        "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
+        "symfony/var-dumper": "~2.7|~3.0|~4.0",
         "nikic/php-parser": "~1.3|~2.0|~3.0",
         "dnoegel/php-xdg-base-dir": "0.1",
         "jakub-onderka/php-console-highlighter": "0.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.4.3",
-        "symfony/finder": "~2.1|~3.0",
+        "symfony/finder": "~2.1|~3.0|~4.0",
         "friendsofphp/php-cs-fixer": "~2.2",
         "hoa/console": "~3.16|~1.14"
     },


### PR DESCRIPTION
Symfony 4 was released November 30th. I added "|~4.0" to all Symfony requirements in composer.json. Things seemed to be working with Symfony 4 components.