### PR TITLE
Improve assertions

### DIFF
--- a/test/Psy/Test/CodeCleaner/CodeCleanerTestCase.php
+++ b/test/Psy/Test/CodeCleaner/CodeCleanerTestCase.php
@@ -66,7 +66,7 @@ class CodeCleanerTestCase extends \PHPUnit\Framework\TestCase
     {
         $stmts = $this->parse($from);
         $stmts = $this->traverse($stmts);
-        $this->assertEquals($to, $this->prettyPrint($stmts));
+        $this->assertSame($to, $this->prettyPrint($stmts));
     }
 
     private function getParser()

--- a/test/Psy/Test/CodeCleaner/NamespacePassTest.php
+++ b/test/Psy/Test/CodeCleaner/NamespacePassTest.php
@@ -31,11 +31,11 @@ class NamespacePassTest extends CodeCleanerTestCase
 
         // A non-block namespace statement should set the current namespace.
         $this->process('namespace Alpha');
-        $this->assertEquals(['Alpha'], $this->cleaner->getNamespace());
+        $this->assertSame(['Alpha'], $this->cleaner->getNamespace());
 
         // A new non-block namespace statement should override the current namespace.
         $this->process('namespace Beta; class B {}');
-        $this->assertEquals(['Beta'], $this->cleaner->getNamespace());
+        $this->assertSame(['Beta'], $this->cleaner->getNamespace());
 
         // A new block namespace clears out the current namespace...
         $this->process('namespace Gamma { array_merge(); }');
@@ -44,7 +44,7 @@ class NamespacePassTest extends CodeCleanerTestCase
             $this->assertNull($this->cleaner->getNamespace());
         } else {
             // But not for PHP-Parser < v3.1.2 :(
-            $this->assertEquals(['Gamma'], $this->cleaner->getNamespace());
+            $this->assertSame(['Gamma'], $this->cleaner->getNamespace());
         }
 
         $this->process('namespace Delta');

--- a/test/Psy/Test/CodeCleanerTest.php
+++ b/test/Psy/Test/CodeCleanerTest.php
@@ -21,7 +21,7 @@ class CodeCleanerTest extends \PHPUnit\Framework\TestCase
     public function testAutomaticSemicolons(array $lines, $requireSemicolons, $expected)
     {
         $cc = new CodeCleaner();
-        $this->assertEquals($expected, $cc->clean($lines, $requireSemicolons));
+        $this->assertSame($expected, $cc->clean($lines, $requireSemicolons));
     }
 
     public function semicolonCodeProvider()

--- a/test/Psy/Test/ConfigurationTest.php
+++ b/test/Psy/Test/ConfigurationTest.php
@@ -30,10 +30,10 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $config = $this->getConfig();
 
-        $this->assertEquals(function_exists('readline'), $config->hasReadline());
-        $this->assertEquals(function_exists('readline'), $config->useReadline());
-        $this->assertEquals(function_exists('pcntl_signal'), $config->hasPcntl());
-        $this->assertEquals(function_exists('pcntl_signal'), $config->usePcntl());
+        $this->assertSame(function_exists('readline'), $config->hasReadline());
+        $this->assertSame(function_exists('readline'), $config->useReadline());
+        $this->assertSame(function_exists('pcntl_signal'), $config->hasPcntl());
+        $this->assertSame(function_exists('pcntl_signal'), $config->usePcntl());
         $this->assertFalse($config->requireSemicolons());
         $this->assertSame(Configuration::COLOR_MODE_AUTO, $config->colorMode());
         $this->assertNull($config->getStartupMessage());
@@ -45,11 +45,11 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNull($config->getDataDir());
         $config->setDataDir('wheee');
-        $this->assertEquals('wheee', $config->getDataDir());
+        $this->assertSame('wheee', $config->getDataDir());
 
         $this->assertNull($config->getConfigDir());
         $config->setConfigDir('wheee');
-        $this->assertEquals('wheee', $config->getConfigDir());
+        $this->assertSame('wheee', $config->getConfigDir());
     }
 
     /**
@@ -61,9 +61,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         putenv("HOME=$home");
 
         $config = new Configuration();
-        $this->assertEquals(realpath($configFile),   realpath($config->getConfigFile()));
-        $this->assertEquals(realpath($historyFile),  realpath($config->getHistoryFile()));
-        $this->assertEquals(realpath($manualDbFile), realpath($config->getManualDbFile()));
+        $this->assertSame(realpath($configFile),   realpath($config->getConfigFile()));
+        $this->assertSame(realpath($historyFile),  realpath($config->getHistoryFile()));
+        $this->assertSame(realpath($manualDbFile), realpath($config->getManualDbFile()));
 
         putenv("HOME=$oldHome");
     }
@@ -116,7 +116,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($cleaner, $config->getCodeCleaner());
         $this->assertSame($pager, $config->getPager());
         $this->assertTrue($config->requireSemicolons());
-        $this->assertEquals(E_ERROR | E_WARNING, $config->errorLoggingLevel());
+        $this->assertSame(E_ERROR | E_WARNING, $config->errorLoggingLevel());
         $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode());
         $this->assertSame('Psysh is awesome!', $config->getStartupMessage());
     }
@@ -131,9 +131,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $this->assertStringStartsWith($runtimeDir, realpath(dirname($config->getPipe('pipe', 123))));
         $this->assertStringStartsWith($runtimeDir, realpath($config->getRuntimeDir()));
 
-        $this->assertEquals(function_exists('readline'), $config->useReadline());
+        $this->assertSame(function_exists('readline'), $config->useReadline());
         $this->assertFalse($config->usePcntl());
-        $this->assertEquals(E_ALL & ~E_NOTICE, $config->errorLoggingLevel());
+        $this->assertSame(E_ALL & ~E_NOTICE, $config->errorLoggingLevel());
     }
 
     public function testLoadLocalConfigFile()
@@ -178,7 +178,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
 
         $includes = $config->getDefaultIncludes();
         $this->assertCount(1, $includes);
-        $this->assertEquals('/file.php', $includes[0]);
+        $this->assertSame('/file.php', $includes[0]);
     }
 
     public function testGetOutput()
@@ -186,7 +186,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $config = $this->getConfig();
         $output = $config->getOutput();
 
-        $this->assertInstanceOf('\Psy\Output\ShellOutput', $output);
+        $this->assertInstanceOf('Psy\Output\ShellOutput', $output);
     }
 
     public function getOutputDecoratedProvider()
@@ -231,7 +231,7 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $config = $this->getConfig();
         $config->setColorMode($colorMode);
 
-        $this->assertEquals($colorMode, $config->colorMode());
+        $this->assertSame($colorMode, $config->colorMode());
     }
 
     /**

--- a/test/Psy/Test/ConsoleColorFactoryTest.php
+++ b/test/Psy/Test/ConsoleColorFactoryTest.php
@@ -24,7 +24,7 @@ class ConsoleColorFactoryTest extends \PHPUnit\Framework\TestCase
         $themes    = $colors->getThemes();
 
         $this->assertFalse($colors->isStyleForced());
-        $this->assertEquals(['blue'], $themes['line_number']);
+        $this->assertSame(['blue'], $themes['line_number']);
     }
 
     public function testGetConsoleColorForced()
@@ -35,7 +35,7 @@ class ConsoleColorFactoryTest extends \PHPUnit\Framework\TestCase
         $themes    = $colors->getThemes();
 
         $this->assertTrue($colors->isStyleForced());
-        $this->assertEquals(['blue'], $themes['line_number']);
+        $this->assertSame(['blue'], $themes['line_number']);
     }
 
     public function testGetConsoleColorDisabled()
@@ -46,6 +46,6 @@ class ConsoleColorFactoryTest extends \PHPUnit\Framework\TestCase
         $themes    = $colors->getThemes();
 
         $this->assertFalse($colors->isStyleForced());
-        $this->assertEquals(['none'], $themes['line_number']);
+        $this->assertSame(['none'], $themes['line_number']);
     }
 }

--- a/test/Psy/Test/Exception/BreakExceptionTest.php
+++ b/test/Psy/Test/Exception/BreakExceptionTest.php
@@ -12,7 +12,6 @@
 namespace Psy\Test\Exception;
 
 use Psy\Exception\BreakException;
-use Psy\Exception\Exception;
 
 class BreakExceptionTest extends \PHPUnit\Framework\TestCase
 {
@@ -20,8 +19,8 @@ class BreakExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $e = new BreakException();
 
-        $this->assertTrue($e instanceof Exception);
-        $this->assertTrue($e instanceof BreakException);
+        $this->assertInstanceOf('Psy\Exception\Exception', $e);
+        $this->assertInstanceOf('Psy\Exception\BreakException', $e);
     }
 
     public function testMessage()
@@ -29,6 +28,6 @@ class BreakExceptionTest extends \PHPUnit\Framework\TestCase
         $e = new BreakException('foo');
 
         $this->assertContains('foo', $e->getMessage());
-        $this->assertEquals('foo', $e->getRawMessage());
+        $this->assertSame('foo', $e->getRawMessage());
     }
 }

--- a/test/Psy/Test/Exception/ErrorExceptionTest.php
+++ b/test/Psy/Test/Exception/ErrorExceptionTest.php
@@ -12,7 +12,6 @@
 namespace Psy\Test\Exception;
 
 use Psy\Exception\ErrorException;
-use Psy\Exception\Exception;
 
 class ErrorExceptionTest extends \PHPUnit\Framework\TestCase
 {
@@ -20,9 +19,9 @@ class ErrorExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $e = new ErrorException();
 
-        $this->assertTrue($e instanceof Exception);
-        $this->assertTrue($e instanceof \ErrorException);
-        $this->assertTrue($e instanceof ErrorException);
+        $this->assertInstanceOf('Psy\Exception\Exception', $e);
+        $this->assertInstanceOf('ErrorException', $e);
+        $this->assertInstanceOf('Psy\Exception\ErrorException', $e);
     }
 
     public function testMessage()
@@ -30,7 +29,7 @@ class ErrorExceptionTest extends \PHPUnit\Framework\TestCase
         $e = new ErrorException('foo');
 
         $this->assertContains('foo', $e->getMessage());
-        $this->assertEquals('foo', $e->getRawMessage());
+        $this->assertSame('foo', $e->getRawMessage());
     }
 
     /**

--- a/test/Psy/Test/Exception/FatalErrorExceptionTest.php
+++ b/test/Psy/Test/Exception/FatalErrorExceptionTest.php
@@ -11,7 +11,6 @@
 
 namespace Psy\Test\Exception;
 
-use Psy\Exception\Exception;
 use Psy\Exception\FatalErrorException;
 
 class FatalErrorExceptionTest extends \PHPUnit\Framework\TestCase
@@ -20,16 +19,16 @@ class FatalErrorExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $e = new FatalErrorException();
 
-        $this->assertTrue($e instanceof Exception);
-        $this->assertTrue($e instanceof \ErrorException);
-        $this->assertTrue($e instanceof FatalErrorException);
+        $this->assertInstanceOf('Psy\Exception\Exception', $e);
+        $this->assertInstanceOf('ErrorException', $e);
+        $this->assertInstanceOf('Psy\Exception\FatalErrorException', $e);
     }
 
     public function testMessage()
     {
         $e = new FatalErrorException('{msg}', 0, 0, '{filename}', 13);
 
-        $this->assertEquals('{msg}', $e->getRawMessage());
+        $this->assertSame('{msg}', $e->getRawMessage());
         $this->assertContains('{msg}', $e->getMessage());
         $this->assertContains('{filename}', $e->getMessage());
         $this->assertContains('line 13', $e->getMessage());
@@ -39,7 +38,7 @@ class FatalErrorExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $e = new FatalErrorException('{msg}');
 
-        $this->assertEquals('{msg}', $e->getRawMessage());
+        $this->assertSame('{msg}', $e->getRawMessage());
         $this->assertContains('{msg}', $e->getMessage());
         $this->assertContains('eval()\'d code', $e->getMessage());
     }

--- a/test/Psy/Test/Exception/ParseErrorExceptionTest.php
+++ b/test/Psy/Test/Exception/ParseErrorExceptionTest.php
@@ -11,7 +11,6 @@
 
 namespace Psy\Test\Exception;
 
-use Psy\Exception\Exception;
 use Psy\Exception\ParseErrorException;
 
 class ParseErrorExceptionTest extends \PHPUnit\Framework\TestCase
@@ -20,9 +19,9 @@ class ParseErrorExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $e = new ParseErrorException();
 
-        $this->assertTrue($e instanceof Exception);
-        $this->assertTrue($e instanceof \PhpParser\Error);
-        $this->assertTrue($e instanceof ParseErrorException);
+        $this->assertInstanceOf('Psy\Exception\Exception', $e);
+        $this->assertInstanceOf('PhpParser\Error', $e);
+        $this->assertInstanceOf('Psy\Exception\ParseErrorException', $e);
     }
 
     public function testMessage()

--- a/test/Psy/Test/Exception/RuntimeExceptionTest.php
+++ b/test/Psy/Test/Exception/RuntimeExceptionTest.php
@@ -11,7 +11,6 @@
 
 namespace Psy\Test\Exception;
 
-use Psy\Exception\Exception;
 use Psy\Exception\RuntimeException;
 
 class RuntimeExceptionTest extends \PHPUnit\Framework\TestCase
@@ -21,11 +20,11 @@ class RuntimeExceptionTest extends \PHPUnit\Framework\TestCase
         $msg = 'bananas';
         $e   = new RuntimeException($msg);
 
-        $this->assertTrue($e instanceof Exception);
-        $this->assertTrue($e instanceof \RuntimeException);
-        $this->assertTrue($e instanceof RuntimeException);
+        $this->assertInstanceOf('Psy\Exception\Exception', $e);
+        $this->assertInstanceOf('RuntimeException', $e);
+        $this->assertInstanceOf('Psy\Exception\RuntimeException', $e);
 
-        $this->assertEquals($msg, $e->getMessage());
-        $this->assertEquals($msg, $e->getRawMessage());
+        $this->assertSame($msg, $e->getMessage());
+        $this->assertSame($msg, $e->getRawMessage());
     }
 }

--- a/test/Psy/Test/Formatter/DocblockFormatterTest.php
+++ b/test/Psy/Test/Formatter/DocblockFormatterTest.php
@@ -55,7 +55,7 @@ class DocblockFormatterTest extends \PHPUnit\Framework\TestCase
 <comment>Author:</comment> Justin Hileman \<justin@justinhileman.info>
 EOS;
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             DocblockFormatter::format(new \ReflectionMethod($this, 'methodWithDocblock'))
         );

--- a/test/Psy/Test/Formatter/SignatureFormatterTest.php
+++ b/test/Psy/Test/Formatter/SignatureFormatterTest.php
@@ -28,7 +28,7 @@ class SignatureFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormat($reflector, $expected)
     {
-        $this->assertEquals($expected, strip_tags(SignatureFormatter::format($reflector)));
+        $this->assertSame($expected, strip_tags(SignatureFormatter::format($reflector)));
     }
 
     public function signatureReflectors()

--- a/test/Psy/Test/Input/ShellInputTest.php
+++ b/test/Psy/Test/Input/ShellInputTest.php
@@ -28,7 +28,7 @@ class ShellInputTest extends \PHPUnit\Framework\TestCase
         $r = new \ReflectionClass('Psy\Input\ShellInput');
         $p = $r->getProperty('tokenPairs');
         $p->setAccessible(true);
-        $this->assertEquals($tokens, $p->getValue($input), $message);
+        $this->assertSame($tokens, $p->getValue($input), $message);
     }
 
     public function testInputOptionWithGivenString()
@@ -40,8 +40,8 @@ class ShellInputTest extends \PHPUnit\Framework\TestCase
 
         $input = new ShellInput('--foo=bar echo "baz\n";');
         $input->bind($definition);
-        $this->assertEquals('bar', $input->getOption('foo'));
-        $this->assertEquals('echo "baz\n";', $input->getArgument('code'));
+        $this->assertSame('bar', $input->getOption('foo'));
+        $this->assertSame('echo "baz\n";', $input->getArgument('code'));
     }
 
     public function testInputOptionWithoutCodeArguments()
@@ -54,9 +54,9 @@ class ShellInputTest extends \PHPUnit\Framework\TestCase
 
         $input = new ShellInput('--foo=foo bar "baz\n"');
         $input->bind($definition);
-        $this->assertEquals('foo', $input->getOption('foo'));
-        $this->assertEquals('bar', $input->getArgument('bar'));
-        $this->assertEquals("baz\n", $input->getArgument('baz'));
+        $this->assertSame('foo', $input->getOption('foo'));
+        $this->assertSame('bar', $input->getArgument('bar'));
+        $this->assertSame("baz\n", $input->getArgument('baz'));
     }
 
     public function getTokenizeData()

--- a/test/Psy/Test/Readline/GNUReadlineTest.php
+++ b/test/Psy/Test/Readline/GNUReadlineTest.php
@@ -32,11 +32,11 @@ class GNUReadlineTest extends \PHPUnit\Framework\TestCase
         $readline = new GNUReadline($this->historyFile);
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
-        $this->assertEquals(['foo'], $readline->listHistory());
+        $this->assertSame(['foo'], $readline->listHistory());
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['foo', 'bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -50,11 +50,11 @@ class GNUReadlineTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'baz'], $readline->listHistory());
         $readline->addHistory('w00t');
-        $this->assertEquals(['baz', 'w00t'], $readline->listHistory());
+        $this->assertSame(['baz', 'w00t'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -69,11 +69,11 @@ class GNUReadlineTest extends \PHPUnit\Framework\TestCase
         $readline->addHistory('foo');
         $readline->addHistory('bar');
         $readline->addHistory('foo');
-        $this->assertEquals(['bar', 'foo'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo'], $readline->listHistory());
         $readline->addHistory('baz');
         $readline->addHistory('w00t');
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }

--- a/test/Psy/Test/Readline/HoaConsoleTest.php
+++ b/test/Psy/Test/Readline/HoaConsoleTest.php
@@ -20,11 +20,11 @@ class HoaConsoleTest extends \PHPUnit\Framework\TestCase
         $readline = new HoaConsole();
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
-        $this->assertEquals(['foo'], $readline->listHistory());
+        $this->assertSame(['foo'], $readline->listHistory());
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['foo', 'bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }

--- a/test/Psy/Test/Readline/LibeditTest.php
+++ b/test/Psy/Test/Readline/LibeditTest.php
@@ -45,11 +45,11 @@ class LibeditTest extends \PHPUnit\Framework\TestCase
         $readline = new Libedit($this->historyFile);
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
-        $this->assertEquals(['foo'], $readline->listHistory());
+        $this->assertSame(['foo'], $readline->listHistory());
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['foo', 'bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -63,11 +63,11 @@ class LibeditTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'baz'], $readline->listHistory());
         $readline->addHistory('w00t');
-        $this->assertEquals(['baz', 'w00t'], $readline->listHistory());
+        $this->assertSame(['baz', 'w00t'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -82,11 +82,11 @@ class LibeditTest extends \PHPUnit\Framework\TestCase
         $readline->addHistory('foo');
         $readline->addHistory('bar');
         $readline->addHistory('foo');
-        $this->assertEquals(['bar', 'foo'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo'], $readline->listHistory());
         $readline->addHistory('baz');
         $readline->addHistory('w00t');
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -99,7 +99,7 @@ class LibeditTest extends \PHPUnit\Framework\TestCase
             "This is an entry\n\0This is a comment\nThis is an entry\0With a comment\n",
             FILE_APPEND
         );
-        $this->assertEquals([
+        $this->assertSame([
             'This is an entry',
             'This is an entry',
         ], $readline->listHistory());
@@ -118,7 +118,7 @@ class LibeditTest extends \PHPUnit\Framework\TestCase
             "foo\rbar\nbaz\r\nw00t",
             FILE_APPEND
         );
-        $this->assertEquals([
+        $this->assertSame([
             "foo\rbar",
             "baz\r",
             'w00t',

--- a/test/Psy/Test/Readline/TransientTest.php
+++ b/test/Psy/Test/Readline/TransientTest.php
@@ -20,11 +20,11 @@ class TransientTest extends \PHPUnit\Framework\TestCase
         $readline = new Transient();
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
-        $this->assertEquals(['foo'], $readline->listHistory());
+        $this->assertSame(['foo'], $readline->listHistory());
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['foo', 'bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -38,11 +38,11 @@ class TransientTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($readline->listHistory());
         $readline->addHistory('foo');
         $readline->addHistory('bar');
-        $this->assertEquals(['foo', 'bar'], $readline->listHistory());
+        $this->assertSame(['foo', 'bar'], $readline->listHistory());
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'baz'], $readline->listHistory());
         $readline->addHistory('w00t');
-        $this->assertEquals(['baz', 'w00t'], $readline->listHistory());
+        $this->assertSame(['baz', 'w00t'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }
@@ -57,11 +57,11 @@ class TransientTest extends \PHPUnit\Framework\TestCase
         $readline->addHistory('foo');
         $readline->addHistory('bar');
         $readline->addHistory('foo');
-        $this->assertEquals(['bar', 'foo'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo'], $readline->listHistory());
         $readline->addHistory('baz');
         $readline->addHistory('w00t');
         $readline->addHistory('baz');
-        $this->assertEquals(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
+        $this->assertSame(['bar', 'foo', 'w00t', 'baz'], $readline->listHistory());
         $readline->clearHistory();
         $this->assertEmpty($readline->listHistory());
     }

--- a/test/Psy/Test/Reflection/ReflectionConstantTest.php
+++ b/test/Psy/Test/Reflection/ReflectionConstantTest.php
@@ -22,12 +22,12 @@ class ReflectionConstantTest extends \PHPUnit\Framework\TestCase
         $refl  = new ReflectionConstant($this, 'CONSTANT_ONE');
         $class = $refl->getDeclaringClass();
 
-        $this->assertTrue($class instanceof \ReflectionClass);
-        $this->assertEquals('Psy\Test\Reflection\ReflectionConstantTest', $class->getName());
-        $this->assertEquals('CONSTANT_ONE', $refl->getName());
-        $this->assertEquals('CONSTANT_ONE', (string) $refl);
-        $this->assertEquals('one', $refl->getValue());
-        $this->assertEquals(null, $refl->getFileName());
+        $this->assertInstanceOf('ReflectionClass', $class);
+        $this->assertSame('Psy\Test\Reflection\ReflectionConstantTest', $class->getName());
+        $this->assertSame('CONSTANT_ONE', $refl->getName());
+        $this->assertSame('CONSTANT_ONE', (string) $refl);
+        $this->assertSame('one', $refl->getValue());
+        $this->assertNull($refl->getFileName());
         $this->assertFalse($refl->getDocComment());
     }
 

--- a/test/Psy/Test/ShellTest.php
+++ b/test/Psy/Test/ShellTest.php
@@ -42,20 +42,20 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $shell->setScopeVariables(compact('one', 'two', 'three', '__psysh__', '_', '_e', 'this'));
 
         $this->assertNotContains('__psysh__', $shell->getScopeVariableNames());
-        $this->assertEquals(['one', 'two', 'three', '_'], $shell->getScopeVariableNames());
-        $this->assertEquals('banana', $shell->getScopeVariable('one'));
-        $this->assertEquals(123, $shell->getScopeVariable('two'));
+        $this->assertSame(['one', 'two', 'three', '_'], $shell->getScopeVariableNames());
+        $this->assertSame('banana', $shell->getScopeVariable('one'));
+        $this->assertSame(123, $shell->getScopeVariable('two'));
         $this->assertSame($three, $shell->getScopeVariable('three'));
         $this->assertNull($shell->getScopeVariable('_'));
 
         $shell->setScopeVariables([]);
-        $this->assertEquals(['_'], $shell->getScopeVariableNames());
+        $this->assertSame(['_'], $shell->getScopeVariableNames());
 
         $shell->setBoundObject($this);
-        $this->assertEquals(['_', 'this'], $shell->getScopeVariableNames());
+        $this->assertSame(['_', 'this'], $shell->getScopeVariableNames());
         $this->assertSame($this, $shell->getScopeVariable('this'));
-        $this->assertEquals(['_' => null], $shell->getScopeVariables(false));
-        $this->assertEquals(['_' => null, 'this' => $this], $shell->getScopeVariables());
+        $this->assertSame(['_' => null], $shell->getScopeVariables(false));
+        $this->assertSame(['_' => null, 'this' => $this], $shell->getScopeVariables());
     }
 
     /**
@@ -75,7 +75,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $shell = new Shell($config);
         $this->assertEmpty($shell->getIncludes());
         $shell->setIncludes(['foo', 'bar', 'baz']);
-        $this->assertEquals(['foo', 'bar', 'baz'], $shell->getIncludes());
+        $this->assertSame(['foo', 'bar', 'baz'], $shell->getIncludes());
     }
 
     public function testIncludesConfig()
@@ -88,7 +88,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $shell = new Shell($config);
 
         $includes = $shell->getIncludes();
-        $this->assertEquals('/file.php', $includes[0]);
+        $this->assertSame('/file.php', $includes[0]);
     }
 
     public function testAddMatchersViaConfig()
@@ -101,7 +101,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         ]);
         $config->setShell($shell);
 
-        $this->assertEquals([$matcher], $shell->matchers);
+        $this->assertSame([$matcher], $shell->matchers);
     }
 
     public function testAddMatchersViaConfigAfterShell()
@@ -113,7 +113,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $config->setShell($shell);
         $config->addMatchers([$matcher]);
 
-        $this->assertEquals([$matcher], $shell->matchers);
+        $this->assertSame([$matcher], $shell->matchers);
     }
 
     public function testRenderingExceptions()
@@ -212,7 +212,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($shell->hasCode());
         $code = preg_replace('/\s+/', ' ', $code);
         $this->assertNotNull($code);
-        $this->assertEquals('class a { } return new \\Psy\\CodeCleaner\\NoReturnValue();', $code);
+        $this->assertSame('class a { } return new \\Psy\\CodeCleaner\\NoReturnValue();', $code);
     }
 
     public function testKeepCodeBufferOpen()
@@ -232,7 +232,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($shell->hasCode());
         $code = preg_replace('/\s+/', ' ', $code);
         $this->assertNotNull($code);
-        $this->assertEquals('return 1 + 1 + 1;', $code);
+        $this->assertSame('return 1 + 1 + 1;', $code);
     }
 
     /**
@@ -253,7 +253,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $shell->flushCode();
         $code = '$test()';
         $shell->addCode($code);
-        $this->assertEquals($shell->flushCode(), 'return $test();');
+        $this->assertSame($shell->flushCode(), 'return $test();');
     }
 
     public function testWriteStdout()
@@ -268,7 +268,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         rewind($stream);
         $streamContents = stream_get_contents($stream);
 
-        $this->assertEquals('{{stdout}}' . PHP_EOL, $streamContents);
+        $this->assertSame('{{stdout}}' . PHP_EOL, $streamContents);
     }
 
     public function testWriteStdoutWithoutNewline()
@@ -283,7 +283,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         rewind($stream);
         $streamContents = stream_get_contents($stream);
 
-        $this->assertEquals('{{stdout}}<aside>⏎</aside>' . PHP_EOL, $streamContents);
+        $this->assertSame('{{stdout}}<aside>⏎</aside>' . PHP_EOL, $streamContents);
     }
 
     /**
@@ -321,7 +321,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
 
         $shell->writeException($exception);
         rewind($stream);
-        $this->assertEquals($expected, stream_get_contents($stream));
+        $this->assertSame($expected, stream_get_contents($stream));
     }
 
     public function getRenderedExceptions()
@@ -342,7 +342,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $shell->setOutput($output);
         $this->assertEquals($expected, $shell->execute($input));
         rewind($stream);
-        $this->assertEquals('', stream_get_contents($stream));
+        $this->assertSame('', stream_get_contents($stream));
     }
 
     public function getExecuteValues()

--- a/test/Psy/Test/Util/DocblockTest.php
+++ b/test/Psy/Test/Util/DocblockTest.php
@@ -31,7 +31,7 @@ class DocblockTest extends \PHPUnit\Framework\TestCase
 
         $docblock = new Docblock($reflector);
 
-        $this->assertEquals($body, $docblock->desc);
+        $this->assertSame($body, $docblock->desc);
 
         foreach ($tags as $tag => $value) {
             $this->assertTrue($docblock->hasTag($tag));

--- a/test/Psy/Test/Util/MirrorTest.php
+++ b/test/Psy/Test/Util/MirrorTest.php
@@ -11,7 +11,6 @@
 
 namespace Psy\Test\Util;
 
-use Psy\Reflection\ReflectionConstant;
 use Psy\Util\Mirror;
 
 class MirrorTest extends \PHPUnit\Framework\TestCase
@@ -28,28 +27,28 @@ class MirrorTest extends \PHPUnit\Framework\TestCase
     public function testMirror()
     {
         $refl = Mirror::get('sort');
-        $this->assertTrue($refl instanceof \ReflectionFunction);
+        $this->assertInstanceOf('ReflectionFunction', $refl);
 
         $refl = Mirror::get('Psy\Test\Util\MirrorTest');
-        $this->assertTrue($refl instanceof \ReflectionClass);
+        $this->assertInstanceOf('ReflectionClass', $refl);
 
         $refl = Mirror::get($this);
-        $this->assertTrue($refl instanceof \ReflectionObject);
+        $this->assertInstanceOf('ReflectionObject', $refl);
 
         $refl = Mirror::get($this, 'FOO');
-        $this->assertTrue($refl instanceof ReflectionConstant);
+        $this->assertInstanceOf('Psy\Reflection\ReflectionConstant', $refl);
 
         $refl = Mirror::get($this, 'bar');
-        $this->assertTrue($refl instanceof \ReflectionProperty);
+        $this->assertInstanceOf('ReflectionProperty', $refl);
 
         $refl = Mirror::get($this, 'baz');
-        $this->assertTrue($refl instanceof \ReflectionProperty);
+        $this->assertInstanceOf('ReflectionProperty', $refl);
 
         $refl = Mirror::get($this, 'aPublicMethod');
-        $this->assertTrue($refl instanceof \ReflectionMethod);
+        $this->assertInstanceOf('ReflectionMethod', $refl);
 
         $refl = Mirror::get($this, 'baz', Mirror::STATIC_PROPERTY);
-        $this->assertTrue($refl instanceof \ReflectionProperty);
+        $this->assertInstanceOf('ReflectionProperty', $refl);
     }
 
     /**

--- a/test/Psy/Test/Util/StrTest.php
+++ b/test/Psy/Test/Util/StrTest.php
@@ -20,7 +20,7 @@ class StrTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnvis($input, $expected)
     {
-        $this->assertEquals($expected, Str::unvis($input));
+        $this->assertSame($expected, Str::unvis($input));
     }
 
     public function unvisProvider()


### PR DESCRIPTION
I've made a little improvement to our tests:
- use PHPUnit assertion methods instead of PHP functions;
- use `assertSame` (===) instead of `assertEquals` (==)