### PR TITLE
Interfaces cannot be instantiate

### DIFF
--- a/src/Psy/ParserFactory.php
+++ b/src/Psy/ParserFactory.php
@@ -83,7 +83,7 @@ class ParserFactory
                 throw new \InvalidArgumentException('Install PHP Parser v2.x to specify parser kind');
             }
 
-            $parser = new Parser(new Lexer());
+            $parser = (new OriginalParserFactory())->create(new Lexer());
         }
 
         return $parser;


### PR DESCRIPTION
Following #460, this one is also a PHPStan fix, but as from it complexity/importance to Psysh, I'm doing separately. From PHPStan:
```
 ------ ------------------------------------------------ 
  Line   ParserFactory.php                               
 ------ ------------------------------------------------ 
  86     Cannot instantiate interface PhpParser\Parser.  
 ------ ------------------------------------------------ 
```
And after check the [`Parser` Interface in PHP-Parser](https://github.com/nikic/PHP-Parser/blob/3.x/lib/PhpParser/Node.php#L5), is right, it is an interface, and we should not instantiate it.

I used [the documentation](https://github.com/nikic/PHP-Parser/blob/3.x/doc/2_Usage_of_basic_components.markdown#parsing) to fix this.

@bobthecow Is this valid? :smile: