### PR TITLE
Feature Proposal: Session Reloading

### DIFF
--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -28,8 +28,8 @@ class ReloadCommand extends Command
     {
         $this
             ->setName('reload')
-            ->setAliases(array('reload!'))
-            ->setDefinition(array())
+            ->setAliases(['reload!'])
+            ->setDefinition([])
             ->setDescription('Reload the current session.')
             ->setHelp(
                 <<<'HELP'
@@ -48,13 +48,13 @@ HELP
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ( !function_exists('pcntl_exec') ) {
+        if (!function_exists('pcntl_exec')) {
             throw new RuntimeException('Unable to reload session (PCNTL is required).');
         }
 
         $output->writeln('<info>Reloading...</info>');
 
-        if ( !defined('PHP_BINARY') ) {
+        if (!defined('PHP_BINARY')) {
             throw new RuntimeException('Unable to identify PHP binary path.');
         }
 

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -11,10 +11,9 @@
 
 namespace Psy\Command;
 
-use Psy\Exception\BreakException;
+use Psy\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Psy\Exception\RuntimeException;
 
 /**
  * Reload the Psy Shell.

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2017 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Command;
+
+use Psy\Exception\BreakException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Psy\Exception\RuntimeException;
+
+/**
+ * Reload the Psy Shell.
+ */
+class ReloadCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('reload')
+            ->setAliases(array('reload!'))
+            ->setDefinition(array())
+            ->setDescription('Reload the current session.')
+            ->setHelp(
+                <<<'HELP'
+Reload the current session.
+
+<warning>Note: The PCNTL extension is required for reload to work.</warning>
+
+e.g.
+<return>>>> reload</return>
+HELP
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ( !function_exists('pcntl_exec') ) {
+            throw new RuntimeException('Unable to reload session (PCNTL is required).');
+        }
+
+        $output->writeln('<info>Reloading...</info>');
+
+        if ( !defined('PHP_BINARY') ) {
+            throw new RuntimeException('Unable to identify PHP binary path.');
+        }
+
+        pcntl_exec(PHP_BINARY, $_SERVER['argv']);
+    }
+}

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -196,6 +196,7 @@ class Shell extends Application
             new Command\BufferCommand(),
             new Command\ClearCommand(),
             new Command\EditCommand($this->config->getRuntimeDir()),
+            new Command\ReloadCommand(),
             // new Command\PsyVersionCommand(),
             $sudo,
             $hist,


### PR DESCRIPTION
This PR adds (relatively basic) functionality to reload the current session in order to bring any new file changes without having to exit and re-launch PsySH. This is accomplished by replacing the current process with an identical one using `pcntl_exec`, automatically reloading files and accounting for any changes (see demonstration below).

## Caveats

Because this is a relatively basic implementation of reloading, there are a few caveats that I think are important to mention (and would love any feedback or suggestions to work around them).

### Stateless Reloads

While this reload method will account for any file changes, what it doesn't do is persist the current state, meaning that any methods defined prior to a `reload` will be forgotten.

Because of this, `reload` may not be the most appropriate command name, so if there are any suggestions for something that better reflects what is happening when the command is run I would love to hear them (`refresh` maybe?).

### PCNTL Required

Because this command utilizes `pcntl_exec` to safely replace the current process with a new one, PCNTL _is_ required. While this isn't necessarily a complication (it is a recommend extension, after all), there doesn't seem to be an established convention for commands that rely on optional dependencies.

I would love any thoughts on how to best handle this. As it stands, the current implementation puts a note in the command help text, and throws an exception on execution if `pcntl_exec` isn't available, however disabling the command altogether when it isn't available might be more desirable.

## Demonstration

![kapture 2018-01-24 at 14 29 55](https://user-images.githubusercontent.com/920019/35358215-164c485c-0113-11e8-8161-a7ebfb264962.gif)

## Relevant Issues:

- #416 - Way to purge or reload modified code without exiting?