### PR TITLE
Add ListPass class that validates before cause fatal error

### DIFF
--- a/src/CodeCleaner.php
+++ b/src/CodeCleaner.php
@@ -26,6 +26,7 @@ use Psy\CodeCleaner\ImplicitReturnPass;
 use Psy\CodeCleaner\InstanceOfPass;
 use Psy\CodeCleaner\LeavePsyshAlonePass;
 use Psy\CodeCleaner\LegacyEmptyPass;
+use Psy\CodeCleaner\ListPass;
 use Psy\CodeCleaner\LoopContextPass;
 use Psy\CodeCleaner\MagicConstantsPass;
 use Psy\CodeCleaner\NamespacePass;
@@ -99,6 +100,7 @@ class CodeCleaner
             new InstanceOfPass(),
             new LeavePsyshAlonePass(),
             new LegacyEmptyPass(),
+            new ListPass(),
             new LoopContextPass(),
             new PassableByReferencePass(),
             new ValidConstructorPass(),

--- a/src/CodeCleaner/ListPass.php
+++ b/src/CodeCleaner/ListPass.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2018 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\CodeCleaner;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\Variable;
+use Psy\Exception\ParseErrorException;
+
+/**
+ * Validate that the list assignment.
+ */
+class ListPass extends CodeCleanerPass
+{
+    /**
+     * Validate use of list assignment.
+     *
+     * @throws ParseErrorException if the user used empty with anything but a variable
+     *
+     * @param Node $node
+     */
+    public function enterNode(Node $node)
+    {
+        if (!$node instanceof Assign) {
+            return;
+        }
+
+        if (!$node->var instanceof Array_ && !$node->var instanceof List_) {
+            return;
+        }
+
+        $before_php71 = version_compare(PHP_VERSION, '7.1', '<');
+
+        if ($node->var instanceof Array_ && $before_php71) {
+            $msg = "syntax error, unexpected '='";
+            throw new ParseErrorException($msg, $node->expr->getLine());
+        }
+
+        if ($node->var->items === [] || $node->var->items === [null]) {
+            throw new ParseErrorException('Cannot use empty list', $node->var->getLine());
+        }
+
+        foreach ($node->var->items as $item) {
+            if ($item === null) {
+                throw new ParseErrorException('Cannot use empty list', $item->getLine());
+            }
+
+            if ($before_php71 && $item->key !== null) {
+                $msg = 'syntax error, unexpected \'\'x\'\' (T_CONSTANT_ENCAPSED_STRING), expecting \',\' or \')\'';
+                throw new ParseErrorException($msg, $item->key->getLine());
+            }
+
+            if (!$item->value instanceof Variable) {
+                $msg = 'Assignments can only happen to writable values';
+                throw new ParseErrorException($msg, $item->value->getLine());
+            }
+        }
+    }
+}

--- a/test/CodeCleaner/ListPassTest.php
+++ b/test/CodeCleaner/ListPassTest.php
@@ -41,7 +41,7 @@ class ListPassTest extends CodeCleanerTestCase
         // Not typo.  It is ambiguous whether "Syntax" or "syntax".
         $error_short_list_assign = "yntax error, unexpected '='";
         $error_empty_list = 'Cannot use empty list';
-        $error_assoc_list_assign = 'syntax error, unexpected \'\'x\'\' (T_CONSTANT_ENCAPSED_STRING), expecting \',\' or \')\'';
+        $error_assoc_list_assign = 'Syntax error, unexpected T_CONSTANT_ENCAPSED_STRING, expecting \',\' or \')\'';
         $error_non_variable_assign = 'Assignments can only happen to writable values';
         $error_php_parser_syntax_paren = 'Syntax error, unexpected \')\'';
         $error_php_parser_syntax_encapsed = 'Syntax error, unexpected T_CONSTANT_ENCAPSED_STRING';

--- a/test/CodeCleaner/ListPassTest.php
+++ b/test/CodeCleaner/ListPassTest.php
@@ -43,23 +43,22 @@ class ListPassTest extends CodeCleanerTestCase
         $error_empty_list = 'Cannot use empty list';
         $error_assoc_list_assign = 'Syntax error, unexpected T_CONSTANT_ENCAPSED_STRING, expecting \',\' or \')\'';
         $error_non_variable_assign = 'Assignments can only happen to writable values';
-        $error_php_parser_syntax_paren = 'Syntax error, unexpected \')\'';
-        $error_php_parser_syntax_encapsed = 'Syntax error, unexpected T_CONSTANT_ENCAPSED_STRING';
+        $error_php_parser_syntax = 'PHP Parse error: Syntax error, unexpected';
 
         $invalid_expr = [
             ['list() = array()', $error_empty_list],
-            ['list("a") = array(1)', $error_php_parser_syntax_paren],
+            ['list("a") = array(1)', $error_php_parser_syntax],
         ];
 
         $invalid_before_71 = [
-            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax_encapsed],
+            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax],
             ['[] = []', $error_short_list_assign],
             ['[$a] = [1]', $error_short_list_assign],
             ['list("a" => $a) = array("a" => 1)', $error_assoc_list_assign],
         ];
 
         $invalid_after_71 = [
-            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax_paren],
+            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax],
             ['[] = []', $error_empty_list],
         ];
 

--- a/test/CodeCleaner/ListPassTest.php
+++ b/test/CodeCleaner/ListPassTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2018 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\CodeCleaner;
+
+use Psy\CodeCleaner\ListPass;
+
+class ListPassTest extends CodeCleanerTestCase
+{
+    public function setUp()
+    {
+        $this->setPass(new ListPass());
+    }
+
+    /**
+     * @dataProvider invalidStatements
+     * @expectedException \Psy\Exception\ParseErrorException
+     */
+    public function testProcessInvalidStatement($code, $expected_message)
+    {
+        $this->expectExceptionMessage($expected_message);
+
+        $stmts = $this->parse($code);
+        $this->traverser->traverse($stmts);
+    }
+
+    public function invalidStatements()
+    {
+        // Not typo.  It is ambiguous whether "Syntax" or "syntax".
+        $error_short_list_assign = "yntax error, unexpected '='";
+        $error_empty_list = 'Cannot use empty list';
+        $error_assoc_list_assign = 'syntax error, unexpected \'\'x\'\' (T_CONSTANT_ENCAPSED_STRING), expecting \',\' or \')\'';
+        $error_non_variable_assign = 'Assignments can only happen to writable values';
+        $error_php_parser_syntax_paren = 'Syntax error, unexpected \')\'';
+        $error_php_parser_syntax_encapsed = 'Syntax error, unexpected T_CONSTANT_ENCAPSED_STRING';
+
+        $invalid_expr = [
+            ['list() = array()', $error_empty_list],
+            ['list("a") = array(1)', $error_php_parser_syntax_paren],
+        ];
+
+        $invalid_before_71 = [
+            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax_encapsed],
+            ['[] = []', $error_short_list_assign],
+            ['[$a] = [1]', $error_short_list_assign],
+            ['list("a" => $a) = array("a" => 1)', $error_assoc_list_assign],
+        ];
+
+        $invalid_after_71 = [
+            ['list("a" => _) = array("a" => 1)', $error_php_parser_syntax_paren],
+            ['[] = []', $error_empty_list],
+        ];
+
+        if (version_compare(PHP_VERSION, '7.1', '<')) {
+            $invalid_expr = array_merge($invalid_expr, $invalid_before_71);
+        } else {
+            $invalid_expr = array_merge($invalid_expr, $invalid_after_71);
+        }
+
+        return $invalid_expr;
+    }
+
+    /**
+     * @dataProvider validStatements
+     */
+    public function testProcessValidStatement($code)
+    {
+        $stmts = $this->parse($code);
+        $this->traverser->traverse($stmts);
+        $this->assertTrue(true);
+    }
+
+    public function validStatements()
+    {
+        $valid_expr = [
+            ['list($a) = array(1)'],
+            ['list($x, $y) = array(1, 2)'],
+        ];
+
+        if (version_compare(PHP_VERSION, '7.1', '>=')) {
+            return array_merge($valid_expr, [
+                ['[$a] = array(1)'],
+                ['list($b) = [2]'],
+                ['[$x, $y] = array(1, 2)'],
+                ['[$a] = [1]'],
+                ['[$x, $y] = [1, 2]'],
+                ['["_" => $v] = ["_" => 1]'],
+            ]);
+        }
+
+        return $valid_expr;
+    }
+}

--- a/test/CodeCleaner/ListPassTest.php
+++ b/test/CodeCleaner/ListPassTest.php
@@ -26,7 +26,11 @@ class ListPassTest extends CodeCleanerTestCase
      */
     public function testProcessInvalidStatement($code, $expected_message)
     {
-        $this->expectExceptionMessage($expected_message);
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException('Psy\Exception\ParseErrorException', $expected_message);
+        } else {
+            $this->expectExceptionMessage($expected_message);
+        }
 
         $stmts = $this->parse($code);
         $this->traverser->traverse($stmts);


### PR DESCRIPTION
This CodePass imitates per-version error on list assignment.

## Before

```
% psysh
Psy Shell v0.8.17 (PHP 7.1.14 — cli) by Justin Hileman
>>> [] = []
PHP Fatal error:  Cannot use empty list in /Users/megurine/.composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code on line 1

Fatal error: Cannot use empty list in /Users/megurine/.composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code on line 1
>>> list() = []
PHP Fatal error:  Cannot use empty list in /Users/megurine/.composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code on line 1

Fatal error: Cannot use empty list in /Users/megurine/.composer/vendor/psy/psysh/src/Psy/ExecutionLoop/Loop.php(90) : eval()'d code on line 1
>>> list(1) = [1]
PHP Parse error: Syntax error, unexpected ')' on line 1
>>> list($a) = [1]
=> [
     1,
   ]
```

## After

```
Psy Shell v0.8.17 (PHP 7.1.14 — cli) by Justin Hileman
>>> [] = []
PHP Parse error: Cannot use empty list on line 1
>>> list() = []
PHP Parse error: Cannot use empty list on line 1
>>> list(1) = [1]
PHP Parse error: Syntax error, unexpected ')' on line 1
>>> list($a) = [1]
=> [
     1,
   ]
```