### PR TITLE
Restore symfony console 2.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/console": "^2.4.2|~3.0|~4.0",
+        "symfony/console": "^~2.3.10|2.4.2|~3.0|~4.0",
         "symfony/var-dumper": "~2.7|~3.0|~4.0",
         "nikic/php-parser": "~2.0|~3.0|~4.0",
         "dnoegel/php-xdg-base-dir": "0.1",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/console": "^~2.3.10|2.4.2|~3.0|~4.0",
+        "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
         "symfony/var-dumper": "~2.7|~3.0|~4.0",
         "nikic/php-parser": "~2.0|~3.0|~4.0",
         "dnoegel/php-xdg-base-dir": "0.1",


### PR DESCRIPTION
Was there a reason this was removed?