### PR TITLE
Add a polyfill for the ctype extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "php": ">=5.4.0",
         "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
         "symfony/var-dumper": "~2.7|~3.0|~4.0",
+        "symfony/polyfill-ctype": "~1.8",
         "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
         "dnoegel/php-xdg-base-dir": "0.1",
         "jakub-onderka/php-console-highlighter": "0.3.*"


### PR DESCRIPTION
A cytpe function is used here: https://github.com/bobthecow/psysh/blob/b8ea8820cd6ea4ea60a40b86ca16aa4c1a237152/src/Util/Docblock.php#L225

But ctype is not always enabled, especially for minimalist distributions like alpine.