### PR TITLE
Accept static method call of trait

### DIFF
--- a/src/CodeCleaner/ValidClassNamePass.php
+++ b/src/CodeCleaner/ValidClassNamePass.php
@@ -249,6 +249,21 @@ class ValidClassNamePass extends NamespaceAwarePass
     }
 
     /**
+     * Ensure that a referenced class _or trait_ exists.
+     *
+     * @throws FatalErrorException
+     *
+     * @param string $name
+     * @param Stmt   $stmt
+     */
+    protected function ensureClassOrTraitExists($name, $stmt)
+    {
+        if (!$this->classExists($name) && !$this->traitExists($name)) {
+            throw $this->createError(\sprintf('Class \'%s\' not found', $name), $stmt);
+        }
+    }
+
+    /**
      * Ensure that a statically called method exists.
      *
      * @throws FatalErrorException
@@ -259,7 +274,7 @@ class ValidClassNamePass extends NamespaceAwarePass
      */
     protected function ensureMethodExists($class, $name, $stmt)
     {
-        $this->ensureClassExists($class, $stmt);
+        $this->ensureClassOrTraitExists($class, $stmt);
 
         // let's pretend all calls to self, parent and static are valid
         if (\in_array(\strtolower($class), ['self', 'parent', 'static'])) {

--- a/test/CodeCleaner/Fixtures/TraitWithStatic.php
+++ b/test/CodeCleaner/Fixtures/TraitWithStatic.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2018 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\CodeCleaner\Fixtures;
+
+trait TraitWithStatic
+{
+    public static function doStuff()
+    {
+        // Don't actually do stuff.
+    }
+}

--- a/test/CodeCleaner/ValidClassNamePassTest.php
+++ b/test/CodeCleaner/ValidClassNamePassTest.php
@@ -172,6 +172,7 @@ class ValidClassNamePassTest extends CodeCleanerTestCase
             ['DateTime::$someMethod()'],
             ['Psy\Test\CodeCleaner\Fixtures\ClassWithStatic::doStuff()'],
             ['Psy\Test\CodeCleaner\Fixtures\ClassWithCallStatic::doStuff()'],
+            ['Psy\Test\CodeCleaner\Fixtures\TraitWithStatic::doStuff()'],
 
             // Allow `self` and `static` as class names.
             ['


### PR DESCRIPTION
Trait's static method can be called without class mixined.

```php
<?php

trait Foo
{
    public static function bar()
    {
        return __METHOD__;
    }
}

var_dump(Foo::bar());
```

https://3v4l.org/hKUHe