### PR TITLE
Bump Box

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -4,7 +4,6 @@
     "compactors": [
         "KevinGH\\Box\\Compactor\\Php"
     ],
-    "chmod": "0755",
     "blacklist": [
         "grammar",
         "test_old",

--- a/vendor-bin/box/composer.json
+++ b/vendor-bin/box/composer.json
@@ -2,6 +2,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "humbug/box": "^3.0@alpha"
+        "humbug/box": "^3.1"
     }
 }


### PR DESCRIPTION
- Bump box to the latest stable (3.1.0)
- Remove an unnecessary setting (the value was the default value)