### PR TITLE
Add PHAR file to GitHub releases (PHIVE support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 after_success:
     - bash <(curl -s https://codecov.io/bash)
 
-before_deploy: make dist -j 4 && cp build/psysh/bin/psysh dist/psysh.phar
+before_deploy: make dist -j 4 && cp build/psysh/psysh dist/psysh.phar && cp build/psysh/psysh.asc dist/psysh.asc
 
 deploy:
     provider: releases
@@ -42,6 +42,7 @@ deploy:
     file:
         - dist/psysh-*.tar.gz
         - dist/psysh.phar
+        - dist/psysh.asc
     skip_cleanup: true
     on:
         tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 after_success:
     - bash <(curl -s https://codecov.io/bash)
 
-before_deploy: make dist -j 4 && cp build/psysh/psysh dist/psysh.phar && cp build/psysh/psysh.asc dist/psysh.asc
+before_deploy: make dist -j 4
 
 deploy:
     provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install: travis_retry composer update --no-interaction $COMPOSER_FLAGS
 
 script:
  - vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
- - '[[ $TRAVIS_PHP_VERSION = 7.2* ]] && make build -j 4 || true'
+ - '[[ $TRAVIS_PHP_VERSION = 7.2* ]] && make build -j 4 && cp build/psysh/bin/psysh dist/psysh.phar || true'
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
@@ -36,7 +36,9 @@ deploy:
   api_key:
     secure: LL8koDM1xDqzF9t0URHvmMPyWjojyd4PeZ7IW7XYgyvD6n1H6GYrVAeKCh5wfUKFbwHoa9s5AAn6pLzra00bODVkPTmUH+FSMWz9JKLw9ODAn8HvN7C+IooxmeClGHFZc0TfHfya8/D1E9C1iXtGGEoE/GqtaYq/z0C1DLpO0OU=
   file_glob: true
-  file: dist/psysh-*.tar.gz
+  file:
+    - dist/psysh-*.tar.gz
+    - dist/psysh.phar
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ install: travis_retry composer update --no-interaction $COMPOSER_FLAGS
 
 script:
  - vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
- - '[[ $TRAVIS_PHP_VERSION = 7.2* ]] && make build -j 4 && cp build/psysh/bin/psysh dist/psysh.phar || true'
+ - '[[ $TRAVIS_PHP_VERSION = 7.2* ]] && make build -j 4 || true'
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-before_deploy: make dist -j 4
+before_deploy: make dist -j 4 && cp build/psysh/bin/psysh dist/psysh.phar
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     file:
         - dist/psysh-*.tar.gz
         - dist/psysh.phar
-        - dist/psysh.asc
+        - dist/psysh.phar.asc
     skip_cleanup: true
     on:
         tags: true

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ clean: ## Clean all created artifacts
 
 dist: ## Build tarballs for distribution
 dist: dist/psysh-$(VERSION).tar.gz dist/psysh-$(VERSION)-compat.tar.gz dist/psysh-$(VERSION)-php54.tar.gz dist/psysh-$(VERSION)-php54-compat.tar.gz
+	cp build/psysh/psysh dist/psysh.phar
+	cp build/psysh/psysh.asc dist/psysh.asc
 
 test: ## Run unit tests
 test: vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean: ## Clean all created artifacts
 dist: ## Build tarballs for distribution
 dist: dist/psysh-$(VERSION).tar.gz dist/psysh-$(VERSION)-compat.tar.gz dist/psysh-$(VERSION)-php54.tar.gz dist/psysh-$(VERSION)-php54-compat.tar.gz
 	cp build/psysh/psysh dist/psysh.phar
-	cp build/psysh/psysh.asc dist/psysh.asc
+	cp build/psysh/psysh.asc dist/psysh.phar.asc
 
 test: ## Run unit tests
 test: vendor/bin/phpunit


### PR DESCRIPTION
Add support for **signed** PHIVE installation. Fix #489.

It will not be available until new release, because PHAR will be added to it.

Also, @bobthecow must set up GPG keys and add them to keyservers so PHAR will be signed. Details how to do that are [on PHIVE site](https://phar.io/howto/sign-and-upload-to-github.html) (section prerequisites) and [in this article](https://andreas.heigl.org/2017/01/19/encrypt-a-build-result-automaticaly/) (all about creating and encrypting keys and adding them to Travis CI environment vars).

Basically, encrypted public and private keys should be added to `.github/keys.asc` in this repository, key ID should be added to Travis CI environment variable `KEY_ID`, decryption key should be added to environment variable `DECRYPT_KEY` and signing key should be added to environment variable `SIGN_KEY`.

This will enable installation with:

```bash
phive install bobthecow/psysh
```

After that, pull request to PHIVE should be added to make alias available.
