### PR TITLE
shell: use default foreground on error, etc

### DIFF
--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -174,13 +174,13 @@ class ShellOutput extends ConsoleOutput
     {
         $formatter = $this->getFormatter();
 
-        $formatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
-        $formatter->setStyle('error',   new OutputFormatterStyle('black', 'red', ['bold']));
+        $formatter->setStyle('warning', new OutputFormatterStyle(null, 'yellow'));
+        $formatter->setStyle('error',   new OutputFormatterStyle(null, 'red', ['bold']));
         $formatter->setStyle('aside',   new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong',  new OutputFormatterStyle(null, null, ['bold']));
         $formatter->setStyle('return',  new OutputFormatterStyle('cyan'));
         $formatter->setStyle('urgent',  new OutputFormatterStyle('red'));
-        $formatter->setStyle('hidden',  new OutputFormatterStyle('black'));
+        $formatter->setStyle('hidden',  new OutputFormatterStyle(null));
 
         // Visibility
         $formatter->setStyle('public',    new OutputFormatterStyle(null, null, ['bold']));


### PR DESCRIPTION
I suggest to use the default foreground colors on error, waring and hidden, otherwise those messages are harder to read on dark terminal themes.

Example: Default on the left side, black on the right side.

![2018-11-21-155011_slurp_grim](https://user-images.githubusercontent.com/350183/48849097-ef00e480-eda5-11e8-878d-0d9fa7ffe7ec.png)
