### PR TITLE
Fixed syntax error in box.json.dist

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -2,7 +2,7 @@
     "stub": "stub",
     "output": "psysh",
     "compactors": [
-        "KevinGH\\Box\\Compactor\\Php",
+        "KevinGH\\Box\\Compactor\\Php"
     ],
     "blacklist": [
         "grammar",


### PR DESCRIPTION
Trailing commas are invalid JSON syntax.