### PR TITLE
Set readline_name

### DIFF
--- a/src/Readline/GNUReadline.php
+++ b/src/Readline/GNUReadline.php
@@ -51,6 +51,7 @@ class GNUReadline implements Readline
         $this->historyFile = ($historyFile !== null) ? $historyFile : false;
         $this->historySize = $historySize;
         $this->eraseDups   = $eraseDups;
+        \readline_info('readline_name', 'psysh');
     }
 
     /**


### PR DESCRIPTION
This allows application-specific bindings in `.intputrc` or `.editrc`.

In `.editrc`, you can set psysh-specific bindings with a `psysh:` prefix:

    psysh:bind "\e[5~" ed-search-prev-history

In `.inputrc`, you can use [conditional init constructs](https://www.gnu.org/software/bash/manual/html_node/Conditional-Init-Constructs.html) (in theory; I don't have readline set up so I didn't test this):

    $if psysh
    "\e[5~": history-search-backward
    $endif

Unconditional/unprefixed bindings will still work.