### PR TITLE
make psysh respect verbosity and interactivity from Symfony Console

### DIFF
--- a/src/ExecutionLoop.php
+++ b/src/ExecutionLoop.php
@@ -29,8 +29,10 @@ class ExecutionLoop
     {
         $this->loadIncludes($shell);
 
-        $closure = new ExecutionLoopClosure($shell);
-        $closure->execute();
+        if ($shell->isInteractive()) {
+            $closure = new ExecutionLoopClosure($shell);
+            $closure->execute();
+        }
     }
 
     /**

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -453,6 +453,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
     private function getInput($input)
     {
         $input = new StringInput($input);
+
         return $input;
     }
 


### PR DESCRIPTION
Symfony Console has flags for both verbosity and interactivity. Respect these flags. The psysh binary itself does not provide these flags, but apps which wrap it as a library (like Laravel Tinker) may.