### PR TITLE
Update default editor to use vi instead of nano

### DIFF
--- a/src/Command/EditCommand.php
+++ b/src/Command/EditCommand.php
@@ -159,7 +159,7 @@ class EditCommand extends Command implements ContextAware
         $escapedFilePath = \escapeshellarg($filePath);
 
         $pipes = [];
-        $proc = \proc_open((\getenv('EDITOR') ?: 'nano') . " {$escapedFilePath}", [STDIN, STDOUT, STDERR], $pipes);
+        $proc = \proc_open((\getenv('EDITOR') ?: 'vi') . " {$escapedFilePath}", [STDIN, STDOUT, STDERR], $pipes);
         \proc_close($proc);
 
         $editedContent = @\file_get_contents($filePath);


### PR DESCRIPTION
- The reason is because `vi` is commonly install by default in light weight Linux distribtuions