### PR TITLE
Fix PHP 7.4 deprecation: The left-associativity of the ternary operator has been deprecated

### DIFF
--- a/src/Formatter/SignatureFormatter.php
+++ b/src/Formatter/SignatureFormatter.php
@@ -287,7 +287,7 @@ class SignatureFormatter implements Formatter
                 } else {
                     $value     = $param->getDefaultValue();
                     $typeStyle = self::getTypeStyle($value);
-                    $value     = \is_array($value) ? 'array()' : \is_null($value) ? 'null' : \var_export($value, true);
+                    $value     = \is_array($value) ? 'array()' : (\is_null($value) ? 'null' : \var_export($value, true));
                 }
                 $default = \sprintf(' = <%s>%s</%s>', $typeStyle, OutputFormatter::escape($value), $typeStyle);
             } else {


### PR DESCRIPTION
PHPCS PHPCompatibility detected a PHP 7.4 deprecation:

The left-associativity of the ternary operator has been deprecated in PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed (PHPCompatibility.Operators.RemovedTernaryAssociativity.Found).