### PR TITLE
Sf5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
+        "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0|~5.0",
         "symfony/var-dumper": "~2.7|~3.0|~4.0",
         "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
         "dnoegel/php-xdg-base-dir": "0.1",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*",
         "ext-tokenizer": "*",
         "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0|~5.0",
-        "symfony/var-dumper": "~2.7|~3.0|~4.0",
+        "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0",
         "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
         "dnoegel/php-xdg-base-dir": "0.1",
         "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*"

--- a/src/Command/BufferCommand.php
+++ b/src/Command/BufferCommand.php
@@ -56,6 +56,8 @@ HELP
         } else {
             $output->writeln($this->formatLines($buf), ShellOutput::NUMBER_LINES);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -45,5 +45,7 @@ HELP
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->write(\sprintf('%c[2J%c[0;0f', 27, 27));
+
+        return 0;
     }
 }

--- a/src/Command/DocCommand.php
+++ b/src/Command/DocCommand.php
@@ -82,6 +82,8 @@ HELP
 
         // Set some magic local variables
         $this->setCommandScopeVariables($reflector);
+
+        return 0;
     }
 
     private function getManualDoc($reflector)

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -76,6 +76,8 @@ HELP
         if (\is_object($target)) {
             $this->setCommandScopeVariables(new \ReflectionObject($target));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/EditCommand.php
+++ b/src/Command/EditCommand.php
@@ -104,6 +104,8 @@ class EditCommand extends Command implements ContextAware
         if ($execute) {
             $this->getApplication()->addInput($editedContent);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -101,5 +101,7 @@ class HelpCommand extends Command
                 $output->stopPaging();
             }
         }
+
+        return 0;
     }
 }

--- a/src/Command/HistoryCommand.php
+++ b/src/Command/HistoryCommand.php
@@ -140,11 +140,13 @@ HELP
         } else {
             $type = $input->getOption('no-numbers') ? 0 : ShellOutput::NUMBER_LINES;
             if (!$highlighted) {
-                $type = $type | ShellOutput::OUTPUT_RAW;
+                $type = $type | OutputInterface::OUTPUT_RAW;
             }
 
             $output->page($highlighted ?: $history, $type);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -143,6 +143,8 @@ HELP
         if ($reflector !== null) {
             $this->setCommandScopeVariables($reflector);
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/ParseCommand.php
+++ b/src/Command/ParseCommand.php
@@ -138,6 +138,8 @@ HELP
         $output->page($this->presenter->present($nodes, $depth));
 
         $this->context->setReturnValue($nodes);
+
+        return 0;
     }
 
     /**

--- a/src/Command/PsyVersionCommand.php
+++ b/src/Command/PsyVersionCommand.php
@@ -37,5 +37,7 @@ class PsyVersionCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln($this->getApplication()->getVersion());
+
+        return 0;
     }
 }

--- a/src/Command/ShowCommand.php
+++ b/src/Command/ShowCommand.php
@@ -18,7 +18,6 @@ use Psy\Exception\RuntimeException;
 use Psy\Formatter\CodeFormatter;
 use Psy\Formatter\SignatureFormatter;
 use Psy\Input\CodeArgument;
-use Psy\Output\ShellOutput;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -99,11 +98,15 @@ HELP
                 throw new \InvalidArgumentException('Too many arguments (supply either "target" or "--ex")');
             }
 
-            return $this->writeExceptionContext($input, $output);
+            $this->writeExceptionContext($input, $output);
+
+            return 0;
         }
 
         if ($input->getArgument('target')) {
-            return $this->writeCodeContext($input, $output);
+            $this->writeCodeContext($input, $output);
+
+            return 0;
         }
 
         throw new RuntimeException('Not enough arguments (missing: "target")');
@@ -117,7 +120,7 @@ HELP
         $this->setCommandScopeVariables($reflector);
 
         try {
-            $output->page(CodeFormatter::format($reflector, $this->colorMode), ShellOutput::OUTPUT_RAW);
+            $output->page(CodeFormatter::format($reflector, $this->colorMode), OutputInterface::OUTPUT_RAW);
         } catch (RuntimeException $e) {
             $output->writeln(SignatureFormatter::format($reflector));
             throw $e;
@@ -216,7 +219,7 @@ HELP
             return;
         }
 
-        $output->write($this->getHighlighter()->getCodeSnippet($code, $line, 5, 5), ShellOutput::OUTPUT_RAW);
+        $output->write($this->getHighlighter()->getCodeSnippet($code, $line, 5, 5), false, OutputInterface::OUTPUT_RAW);
     }
 
     private function getHighlighter()

--- a/src/Command/SudoCommand.php
+++ b/src/Command/SudoCommand.php
@@ -118,6 +118,8 @@ HELP
         $sudoCode = $this->printer->prettyPrint($nodes);
         $shell = $this->getApplication();
         $shell->addCode($sudoCode, !$shell->hasCode());
+
+        return 0;
     }
 
     /**

--- a/src/Command/ThrowUpCommand.php
+++ b/src/Command/ThrowUpCommand.php
@@ -105,6 +105,8 @@ HELP
 
         $shell = $this->getApplication();
         $shell->addCode($throwCode, !$shell->hasCode());
+
+        return 0;
     }
 
     /**

--- a/src/Command/TimeitCommand.php
+++ b/src/Command/TimeitCommand.php
@@ -106,6 +106,8 @@ HELP
 
             $output->writeln(\sprintf(self::AVG_RESULT_MSG, $total / $num, $median, $total));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/TraceCommand.php
+++ b/src/Command/TraceCommand.php
@@ -74,6 +74,8 @@ HELP
         $this->filter->bind($input);
         $trace = $this->getBacktrace(new \Exception(), $input->getOption('num'), $input->getOption('include-psy'));
         $output->page($trace, ShellOutput::NUMBER_LINES);
+
+        return 0;
     }
 
     /**

--- a/src/Command/WhereamiCommand.php
+++ b/src/Command/WhereamiCommand.php
@@ -14,7 +14,6 @@ namespace Psy\Command;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 use Psy\Configuration;
 use Psy\ConsoleColorFactory;
-use Psy\Output\ShellOutput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -126,11 +125,13 @@ HELP
         $output->writeln('');
         $output->writeln(\sprintf('From <info>%s:%s</info>:', $this->replaceCwd($info['file']), $info['line']));
         $output->writeln('');
-        $output->write($highlighter->getCodeSnippet($contents, $info['line'], $num, $num), ShellOutput::OUTPUT_RAW);
+        $output->write($highlighter->getCodeSnippet($contents, $info['line'], $num, $num), false, OutputInterface::OUTPUT_RAW);
 
         if ($output instanceof ShellOutput) {
             $output->stopPaging();
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/WtfCommand.php
+++ b/src/Command/WtfCommand.php
@@ -128,5 +128,7 @@ HELP
         if ($output instanceof ShellOutput) {
             $output->stopPaging();
         }
+
+        return 0;
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -19,13 +19,13 @@ use Psy\Readline\GNUReadline;
 use Psy\Readline\HoaConsole;
 use Psy\Readline\Libedit;
 use Psy\Readline\Readline;
-use Psy\Readline\Transient;
 use Psy\TabCompletion\AutoCompleter;
 use Psy\VarDumper\Presenter;
 use Psy\VersionUpdater\Checker;
 use Psy\VersionUpdater\GitHubChecker;
 use Psy\VersionUpdater\IntervalChecker;
 use Psy\VersionUpdater\NoopChecker;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The Psy Shell configuration.
@@ -847,7 +847,7 @@ class Configuration
     {
         if (!isset($this->output)) {
             $this->output = new ShellOutput(
-                ShellOutput::VERBOSITY_NORMAL,
+                OutputInterface::VERBOSITY_NORMAL,
                 $this->getOutputDecorated(),
                 null,
                 $this->getPager()

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -21,7 +21,6 @@ use Psy\ExecutionLoop\ProcessForker;
 use Psy\ExecutionLoop\RunkitReloader;
 use Psy\Input\ShellInput;
 use Psy\Input\SilentInput;
-use Psy\Output\ShellOutput;
 use Psy\TabCompletion\Matcher;
 use Psy\VarDumper\PresenterAware;
 use Symfony\Component\Console\Application;
@@ -1016,7 +1015,7 @@ class Shell extends Application
 
         // Incremental flush
         if ($out !== '' && !$isCleaning) {
-            $this->output->write($out, false, ShellOutput::OUTPUT_RAW);
+            $this->output->write($out, false, OutputInterface::OUTPUT_RAW);
             $this->outputWantsNewline = (\substr($out, -1) !== "\n");
             $this->stdoutBuffer .= $out;
         }


### PR DESCRIPTION
Add compatibility for Symfony 5.

I had to "fix" a call on a few `write` call from the Output to match the signature that is used since ~2.0 of symfony.

#SymfonyHackday