### PR TITLE
Test on HHVM 3 insead of 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - php: 7.2
         - php: 7.3
         - php: 7.4
-        - php: hhvm
+        - php: hhvm-3.30
           dist: trusty
     allow_failures:
         - php: 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - php: 7.2
         - php: 7.3
         - php: 7.4
-        - php: hhvm-3.30
+        - php: hhvm-3.18
           dist: trusty
     allow_failures:
         - php: 5.4


### PR DESCRIPTION
HHVM has intentionally stopping being compatible with PHP as of v4.0. Composer won't even run on HHVM 4. We should test on the last LTS release of HHVM 3, which is the version anyone using HHVM who uses lots of PHP libs (and not hacklang) will be using.