### PR TITLE
Make error message readable - switch to white text on red background

### DIFF
--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -175,7 +175,7 @@ class ShellOutput extends ConsoleOutput
         $formatter = $this->getFormatter();
 
         $formatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
-        $formatter->setStyle('error',   new OutputFormatterStyle('black', 'red', ['bold']));
+        $formatter->setStyle('error',   new OutputFormatterStyle('white', 'red', ['bold']));
         $formatter->setStyle('aside',   new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong',  new OutputFormatterStyle(null, null, ['bold']));
         $formatter->setStyle('return',  new OutputFormatterStyle('cyan'));


### PR DESCRIPTION
The error messages were not readable without highlighting. Switch to white text on red background.