### PR TITLE
Fix unreadable error messages on some systems

### DIFF
--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -175,7 +175,7 @@ class ShellOutput extends ConsoleOutput
         $formatter = $this->getFormatter();
 
         $formatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
-        $formatter->setStyle('error',   new OutputFormatterStyle('black', 'red', ['bold']));
+        $formatter->setStyle('error',   new OutputFormatterStyle('white', 'red', ['bold']));
         $formatter->setStyle('aside',   new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong',  new OutputFormatterStyle(null, null, ['bold']));
         $formatter->setStyle('return',  new OutputFormatterStyle('cyan'));


### PR DESCRIPTION
The error message has black on red text which turns unreadable on some systems, Suggest changing it to white omn red.