### PR TITLE
Fix `ReflectionClassConstant` class_exist() call

### DIFF
--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -219,7 +219,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public static function create($class, $name)
     {
-        if (\class_exists('ReflectionClassConstant')) {
+        if (\class_exists(\ReflectionClassConstant::class)) {
             return new \ReflectionClassConstant($class, $name);
         }
 

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -219,7 +219,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public static function create($class, $name)
     {
-        if (\class_exists(\ReflectionClassConstant::class)) {
+        if (\class_exists('ReflectionClassConstant')) {
             return new \ReflectionClassConstant($class, $name);
         }
 

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -219,7 +219,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public static function create($class, $name)
     {
-        if (\class_exists('\\ReflectionClassConstant')) {
+        if (\class_exists('ReflectionClassConstant')) {
             return new \ReflectionClassConstant($class, $name);
         }
 


### PR DESCRIPTION
Closes https://github.com/bobthecow/psysh/issues/581

I'm fixing the issue on PHP-Scoper side as well, but the idea is that in `class_exists()` and similar functions, symbol paths are always the fully qualified names so the leading `\` is unnecessary