### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "bin": ["bin/psysh"],
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.9.x-dev"
+            "dev-develop": "0.10.x-dev"
         }
     }
 }


### PR DESCRIPTION
The master branch looks like it's actually `0.9.x-dev` at the moment. I suppose `develop` is now representing either `0.10.x-dev` or `1.0.x-dev`?