### PR TITLE
Enable PHP 7.3 and PHP 7.4 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
     - php: hhvm
       dist: trusty
   allow_failures:


### PR DESCRIPTION
The build is expected to fail until #602 is resolved.