### PR TITLE
Support PHP7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /build/
 /dist/
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
     - php: hhvm
       dist: trusty
   allow_failures:
@@ -26,7 +28,7 @@ matrix:
 install: travis_retry composer update --no-interaction $COMPOSER_FLAGS
 
 script:
- - vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
+ - vendor/bin/phpunit --fail-on-warning --verbose --coverage-clover=coverage.xml
  - '[[ $TRAVIS_PHP_VERSION = 7.2* ]] && make build -j 4 || true'
 
 after_success:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
+<phpunit backupGlobals="false" colors="true" bootstrap="test/bootstrap.php">
 	<testsuite name="PsySH">
 		<directory suffix="Test.php">./test</directory>
 	</testsuite>

--- a/src/Formatter/SignatureFormatter.php
+++ b/src/Formatter/SignatureFormatter.php
@@ -287,7 +287,7 @@ class SignatureFormatter implements Formatter
                 } else {
                     $value     = $param->getDefaultValue();
                     $typeStyle = self::getTypeStyle($value);
-                    $value     = \is_array($value) ? 'array()' : \is_null($value) ? 'null' : \var_export($value, true);
+                    $value     = \is_array($value) ? 'array()' : (\is_null($value) ? 'null' : \var_export($value, true));
                 }
                 $default = \sprintf(' = <%s>%s</%s>', $typeStyle, OutputFormatter::escape($value), $typeStyle);
             } else {

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+error_reporting(E_ALL);
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## How to roll?

1. Temporary add showing all errors `error_reporting(E_ALL);` to `SignatureFormatterTest` class.
2. Run test with flag `--fail-on-warning`, like that: `php vendor/bin/phpunit --fail-on-warning`

## Fixed
https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary

## Additional impovements
Added `.idea` folder to `.gitignore`
Added PHP 7.3 and PHP 7.4 to Travis CI building.
Added `bootstrap` for tests.