### PR TITLE
Removed extra method

### DIFF
--- a/src/Readline/HoaConsole.php
+++ b/src/Readline/HoaConsole.php
@@ -37,7 +37,11 @@ class HoaConsole implements Readline
     public function __construct()
     {
         $this->hoaReadline = new HoaReadline();
-        $this->hoaReadline->addMapping('\C-l', [$this, '_redisplay']);
+        $this->hoaReadline->addMapping('\C-l', function () {
+            $this->redisplay();
+
+            return HoaReadline::STATE_NO_ECHO;
+        });
     }
 
     /**

--- a/src/Readline/HoaConsole.php
+++ b/src/Readline/HoaConsole.php
@@ -101,19 +101,9 @@ class HoaConsole implements Readline
      */
     public function redisplay()
     {
-        $this->_redisplay();
-    }
-
-    /**
-     * @return int
-     */
-    public function _redisplay()
-    {
         $currentLine = $this->hoaReadline->getLine();
         Cursor::clear('all');
         echo $this->lastPrompt, $currentLine;
-
-        return HoaReadline::STATE_NO_ECHO;
     }
 
     /**


### PR DESCRIPTION
`_redisplay` is not in the interface, and has a non-PSR name. Why was it added?