### PR TITLE
Tweaked hoa/console version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jakub-onderka/php-console-highlighter": "0.4.*|0.3.*"
     },
     "require-dev": {
-        "hoa/console": "~3.16|~2.15",
+        "hoa/console": "3.17.*",
         "bamarni/composer-bin-plugin": "^1.2"
     },
     "suggest": {


### PR DESCRIPTION
Looks like they are not following semver. `master` is aliased as 3.x, yet they have made breaking changes to method signatures of non-final classes: https://github.com/hoaproject/Console/compare/3.17.05.02...master.