### PR TITLE
Better plumbing.

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -34,6 +34,10 @@ class Configuration
     const COLOR_MODE_FORCED   = 'forced';
     const COLOR_MODE_DISABLED = 'disabled';
 
+    const INTERACTIVE_MODE_AUTO     = 'auto';
+    const INTERACTIVE_MODE_FORCED   = 'forced';
+    const INTERACTIVE_MODE_DISABLED = 'disabled';
+
     const VERBOSITY_QUIET        = 'quiet';
     const VERBOSITY_NORMAL       = 'normal';
     const VERBOSITY_VERBOSE      = 'verbose';
@@ -51,6 +55,7 @@ class Configuration
         'forceArrayIndexes',
         'formatterStyles',
         'historySize',
+        'interactiveMode',
         'manualDbFile',
         'pager',
         'prompt',
@@ -94,6 +99,7 @@ class Configuration
     private $errorLoggingLevel = E_ALL;
     private $warnOnMultipleConfigs = false;
     private $colorMode = self::COLOR_MODE_AUTO;
+    private $interactiveMode = self::INTERACTIVE_MODE_AUTO;
     private $updateCheck;
     private $startupMessage;
     private $forceArrayIndexes = false;
@@ -896,6 +902,23 @@ class Configuration
     }
 
     /**
+     * Get the interactive setting for shell input.
+     *
+     * @return bool
+     */
+    public function getInputInteractive()
+    {
+        switch ($this->interactiveMode()) {
+            case self::INTERACTIVE_MODE_AUTO:
+                return !$this->inputIsPiped();
+            case self::INTERACTIVE_MODE_FORCED:
+                return true;
+            case self::INTERACTIVE_MODE_DISABLED:
+                return false;
+        }
+    }
+
+    /**
      * Set the OutputPager service.
      *
      * If a string is supplied, a ProcOutputPager will be used which shells out
@@ -1195,6 +1218,36 @@ class Configuration
     public function colorMode()
     {
         return $this->colorMode;
+    }
+
+    /**
+     * Set the shell's interactive mode.
+     *
+     * @param string $interactiveMode
+     */
+    public function setInteractiveMode($interactiveMode)
+    {
+        $validInteractiveModes = [
+            self::INTERACTIVE_MODE_AUTO,
+            self::INTERACTIVE_MODE_FORCED,
+            self::INTERACTIVE_MODE_DISABLED,
+        ];
+
+        if (!\in_array($interactiveMode, $validInteractiveModes)) {
+            throw new \InvalidArgumentException('Invalid interactive mode: ' . $interactiveMode);
+        }
+
+        $this->interactiveMode = $interactiveMode;
+    }
+
+    /**
+     * Get the current interactive mode.
+     *
+     * @return string
+     */
+    public function interactiveMode()
+    {
+        return $this->interactiveMode;
     }
 
     /**

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -26,7 +26,7 @@ use Psy\VarDumper\PresenterAware;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -302,9 +302,8 @@ class Shell extends Application
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
-        if ($input === null && !isset($_SERVER['argv'])) {
-            $input = new ArgvInput([]);
-        }
+        // We'll just ignore the input passed in, and set up our own!
+        $input = new ArrayInput([]);
 
         if ($output === null) {
             $output = $this->config->getOutput();
@@ -403,6 +402,21 @@ class Shell extends Application
         }
 
         $this->afterRun();
+    }
+
+    /**
+     * Configures the input and output instances based on the user arguments and options.
+     */
+    protected function configureIO(InputInterface $input, OutputInterface $output)
+    {
+        // @todo overrides via environment variables (or should these happen in config? ... probably config)
+        $input->setInteractive($this->config->getInputInteractive());
+
+        if ($this->config->getOutputDecorated() !== null) {
+            $output->setDecorated($this->config->getOutputDecorated());
+        }
+
+        $output->setVerbosity($this->config->getOutputVerbosity());
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -171,6 +171,11 @@ if (!\function_exists('Psy\\info')) {
             'update cache file'      => $prettyPath($config->getUpdateCheckCacheFile()),
         ];
 
+        $input = [
+            'interactive mode'  => $config->interactiveMode(),
+            'input interactive' => $config->getInputInteractive(),
+        ];
+
         if ($config->hasReadline()) {
             $info = \readline_info();
 
@@ -269,7 +274,7 @@ if (!\function_exists('Psy\\info')) {
 
         // @todo Show Presenter / custom casters.
 
-        return \array_merge($core, \compact('updates', 'pcntl', 'readline', 'output', 'history', 'docs', 'autocomplete'));
+        return \array_merge($core, \compact('updates', 'pcntl', 'input', 'readline', 'output', 'history', 'docs', 'autocomplete'));
     }
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -193,6 +193,12 @@ if (!\function_exists('Psy\\info')) {
             ];
         }
 
+        $output = [
+            'color mode'       => $config->colorMode(),
+            'output decorated' => $config->getOutputDecorated(),
+            'output verbosity' => $config->verbosity(),
+        ];
+
         $pcntl = [
             'pcntl available' => ProcessForker::isPcntlSupported(),
             'posix available' => ProcessForker::isPosixSupported(),
@@ -263,7 +269,7 @@ if (!\function_exists('Psy\\info')) {
 
         // @todo Show Presenter / custom casters.
 
-        return \array_merge($core, \compact('updates', 'pcntl', 'readline', 'history', 'docs', 'autocomplete'));
+        return \array_merge($core, \compact('updates', 'pcntl', 'readline', 'output', 'history', 'docs', 'autocomplete'));
     }
 }
 

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -18,6 +18,7 @@ use Psy\Output\PassthruPager;
 use Psy\Output\ShellOutput;
 use Psy\VersionUpdater\GitHubChecker;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
@@ -248,6 +249,56 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $config = $this->getConfig();
         $config->setColorMode('some invalid mode');
+    }
+
+    public function getOutputVerbosityProvider()
+    {
+        return [
+            'quiet'        => [OutputInterface::VERBOSITY_QUIET, Configuration::VERBOSITY_QUIET],
+            'normal'       => [OutputInterface::VERBOSITY_NORMAL, Configuration::VERBOSITY_NORMAL],
+            'verbose'      => [OutputInterface::VERBOSITY_VERBOSE, Configuration::VERBOSITY_VERBOSE],
+            'very_verbose' => [OutputInterface::VERBOSITY_VERY_VERBOSE, Configuration::VERBOSITY_VERY_VERBOSE],
+            'debug'        => [OutputInterface::VERBOSITY_DEBUG, Configuration::VERBOSITY_DEBUG],
+        ];
+    }
+
+    /** @dataProvider getOutputVerbosityProvider */
+    public function testGetOutputVerbosity($expectation, $verbosity)
+    {
+        $config = $this->getConfig();
+        $config->setVerbosity($verbosity);
+
+        $this->assertSame($expectation, $config->getOutputVerbosity());
+    }
+
+    public function setVerbosityValidProvider()
+    {
+        return [
+            'quiet'        => [Configuration::VERBOSITY_QUIET],
+            'normal'       => [Configuration::VERBOSITY_NORMAL],
+            'verbose'      => [Configuration::VERBOSITY_VERBOSE],
+            'very_verbose' => [Configuration::VERBOSITY_VERY_VERBOSE],
+            'debug'        => [Configuration::VERBOSITY_DEBUG],
+        ];
+    }
+
+    /** @dataProvider setVerbosityValidProvider */
+    public function testSetVerbosityValid($verbosity)
+    {
+        $config = $this->getConfig();
+        $config->setVerbosity($verbosity);
+
+        $this->assertSame($verbosity, $config->verbosity());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid verbosity level: some invalid verbosity
+     */
+    public function testSetVerbosityInvalid()
+    {
+        $config = $this->getConfig();
+        $config->setVerbosity('some invalid verbosity');
     }
 
     public function testSetCheckerValid()

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -212,6 +212,10 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     /** @dataProvider getOutputDecoratedProvider */
     public function testGetOutputDecorated($expectation, $colorMode)
     {
+        if ($colorMode === Configuration::COLOR_MODE_AUTO) {
+            $this->markTestSkipped('This test won\'t work on CI without overriding pipe detection');
+        }
+
         $config = $this->getConfig();
         $config->setColorMode($colorMode);
 

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -17,6 +17,8 @@ use Psy\ExecutionLoop\ProcessForker;
 use Psy\Output\PassthruPager;
 use Psy\Output\ShellOutput;
 use Psy\VersionUpdater\GitHubChecker;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -157,6 +159,16 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($config->useUnicode());
 
         \chdir($oldPwd);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid configuration file specified
+     */
+    public function testUnknownConfigFileThrowsException()
+    {
+        $config = new Configuration(['configFile' => __DIR__ . '/not/a/real/config.php']);
+        $this->assertFalse(true);
     }
 
     /**
@@ -456,5 +468,149 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
                 'Invalid option specified: "marquee". Expected one of',
             ],
         ];
+    }
+
+    /**
+     * @dataProvider inputStrings
+     */
+    public function testConfigurationFromInput($inputString, $verbosity, $colorMode, $interactiveMode, $rawOutput)
+    {
+        $input = $this->getBoundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertEquals($colorMode, $config->colorMode());
+        $this->assertEquals($interactiveMode, $config->interactiveMode());
+        $this->assertEquals($rawOutput, $config->rawOutput());
+
+        $input = $this->getUnboundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertEquals($colorMode, $config->colorMode());
+        $this->assertEquals($interactiveMode, $config->interactiveMode());
+        $this->assertEquals($rawOutput, $config->rawOutput());
+    }
+
+    public function inputStrings()
+    {
+        return [
+            ['', Configuration::VERBOSITY_NORMAL, Configuration::COLOR_MODE_AUTO, Configuration::INTERACTIVE_MODE_AUTO, false],
+            ['--raw-output --color --interactive --verbose', Configuration::VERBOSITY_VERBOSE, Configuration::COLOR_MODE_FORCED, Configuration::INTERACTIVE_MODE_FORCED, false],
+            ['--raw-output --no-color --no-interactive --quiet', Configuration::VERBOSITY_QUIET, Configuration::COLOR_MODE_DISABLED, Configuration::INTERACTIVE_MODE_DISABLED, true],
+            ['--quiet --color --interactive', Configuration::VERBOSITY_QUIET, Configuration::COLOR_MODE_FORCED, Configuration::INTERACTIVE_MODE_FORCED, false],
+        ];
+    }
+
+    public function testConfigurationFromInputSpecificity()
+    {
+        $input = $this->getBoundStringInput('--raw-output --color --interactive --verbose');
+        $config = Configuration::fromInput($input);
+        $this->assertEquals(Configuration::VERBOSITY_VERBOSE, $config->verbosity());
+        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode());
+        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
+        $this->assertFalse($config->rawOutput(), '--raw-output is ignored with interactive input');
+
+        $input = $this->getBoundStringInput('--verbose --quiet --color --no-color --interactive --no-interactive');
+        $config = Configuration::fromInput($input);
+        $this->assertEquals(Configuration::VERBOSITY_QUIET, $config->verbosity(), '--quiet trumps --verbose');
+        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode(), '--color trumps --no-color');
+        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode(), '--interactive trumps --no-interactive');
+    }
+
+    /**
+     * @dataProvider verbosityInputStrings
+     */
+    public function testConfigurationFromInputVerbosityLevels($inputString, $verbosity)
+    {
+        $input = $this->getBoundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+
+        $input = $this->getUnboundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+    }
+
+    public function verbosityInputStrings()
+    {
+        return [
+            ['--verbose 0',  Configuration::VERBOSITY_NORMAL],
+            ['--verbose=0',  Configuration::VERBOSITY_NORMAL],
+            ['--verbose 1',  Configuration::VERBOSITY_VERBOSE],
+            ['--verbose=1',  Configuration::VERBOSITY_VERBOSE],
+            ['-v',           Configuration::VERBOSITY_VERBOSE],
+            ['--verbose 2',  Configuration::VERBOSITY_VERY_VERBOSE],
+            ['--verbose=2',  Configuration::VERBOSITY_VERY_VERBOSE],
+            ['-vv',          Configuration::VERBOSITY_VERY_VERBOSE],
+            ['--verbose 3',  Configuration::VERBOSITY_DEBUG],
+            ['--verbose=3',  Configuration::VERBOSITY_DEBUG],
+            ['-vvv',         Configuration::VERBOSITY_DEBUG],
+            // no `--verbose -1` because that's not a valid option value :P
+            ['--verbose=-1', Configuration::VERBOSITY_QUIET],
+            ['--quiet', Configuration::VERBOSITY_QUIET],
+        ];
+    }
+
+    /**
+     * @dataProvider shortInputStrings
+     */
+    public function testConfigurationFromInputShortOptions($inputString, $verbosity, $interactiveMode, $rawOutput, $skipUnbound = false)
+    {
+        $input = $this->getBoundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertEquals($interactiveMode, $config->interactiveMode());
+        $this->assertEquals($rawOutput, $config->rawOutput());
+
+        if ($skipUnbound) {
+            $this->markTestSkipped($inputString . ' fails with unbound input');
+        }
+
+        $input = $this->getUnboundStringInput($inputString);
+        $config = Configuration::fromInput($input);
+        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertEquals($interactiveMode, $config->interactiveMode());
+        $this->assertEquals($rawOutput, $config->rawOutput());
+    }
+
+    public function shortInputStrings()
+    {
+        return [
+            // Can't do `-nrq`-style compact short options with unbound input.
+            ['-nrq',     Configuration::VERBOSITY_QUIET,        Configuration::INTERACTIVE_MODE_DISABLED, true, true],
+            ['-n -r -q', Configuration::VERBOSITY_QUIET,        Configuration::INTERACTIVE_MODE_DISABLED, true],
+            ['-v',       Configuration::VERBOSITY_VERBOSE,      Configuration::INTERACTIVE_MODE_AUTO,     false],
+            ['-vv',      Configuration::VERBOSITY_VERY_VERBOSE, Configuration::INTERACTIVE_MODE_AUTO,     false],
+            ['-vvv',     Configuration::VERBOSITY_DEBUG,        Configuration::INTERACTIVE_MODE_AUTO,     false],
+        ];
+    }
+
+    public function testConfigurationFromInputAliases()
+    {
+        $input = $this->getBoundStringInput('--ansi --interaction');
+        $config = Configuration::fromInput($input);
+        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode());
+        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
+
+        $input = $this->getBoundStringInput('--no-ansi --no-interaction');
+        $config = Configuration::fromInput($input);
+        $this->assertEquals(Configuration::COLOR_MODE_DISABLED, $config->colorMode());
+        $this->assertEquals(Configuration::INTERACTIVE_MODE_DISABLED, $config->interactiveMode());
+    }
+
+    private function getBoundStringInput($string, $configFile = null)
+    {
+        $input = $this->getUnboundStringInput($string, $configFile);
+        $input->bind(new InputDefinition(Configuration::getInputOptions()));
+
+        return $input;
+    }
+
+    private function getUnboundStringInput($string, $configFile = null)
+    {
+        if ($configFile === null) {
+            $configFile = __DIR__ . '/fixtures/empty.php';
+        }
+
+        return new StringInput($string . ' --config ' . \escapeshellarg($configFile));
     }
 }

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -301,6 +301,65 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $config->setVerbosity('some invalid verbosity');
     }
 
+    public function getInputInteractiveProvider()
+    {
+        return [
+            'auto' => [
+                null,
+                Configuration::INTERACTIVE_MODE_AUTO,
+            ],
+            'forced' => [
+                true,
+                Configuration::INTERACTIVE_MODE_FORCED,
+            ],
+            'disabled' => [
+                false,
+                Configuration::INTERACTIVE_MODE_DISABLED,
+            ],
+        ];
+    }
+
+    /** @dataProvider getInputInteractiveProvider */
+    public function testGetInputInteractive($expectation, $interactive)
+    {
+        if ($interactive === Configuration::INTERACTIVE_MODE_AUTO) {
+            $this->markTestSkipped('This test won\'t work on CI without overriding pipe detection');
+        }
+
+        $config = $this->getConfig();
+        $config->setInteractiveMode($interactive);
+
+        $this->assertSame($expectation, $config->getInputInteractive());
+    }
+
+    public function setInteractiveModeValidProvider()
+    {
+        return [
+            'auto'     => [Configuration::INTERACTIVE_MODE_AUTO],
+            'forced'   => [Configuration::INTERACTIVE_MODE_FORCED],
+            'disabled' => [Configuration::INTERACTIVE_MODE_DISABLED],
+        ];
+    }
+
+    /** @dataProvider setInteractiveModeValidProvider */
+    public function testsetInteractiveModeValid($interactive)
+    {
+        $config = $this->getConfig();
+        $config->setInteractiveMode($interactive);
+
+        $this->assertSame($interactive, $config->interactiveMode());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid interactive mode: nope
+     */
+    public function testsetInteractiveModeInvalid()
+    {
+        $config = $this->getConfig();
+        $config->setInteractiveMode('nope');
+    }
+
     public function testSetCheckerValid()
     {
         $config  = $this->getConfig();

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -112,11 +112,13 @@ class ShellTest extends \PHPUnit\Framework\TestCase
 
     public function testNonInteractiveDoesNotUpdateContext()
     {
-        $config = $this->getConfig(['usePcntl' => false]);
+        $config = $this->getConfig([
+            'usePcntl'        => false,
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
         $shell = new Shell($config);
 
         $input = $this->getInput('');
-        $input->setInteractive(false);
 
         $shell->addInput('$var=5;', true);
         $shell->addInput('exit', true);
@@ -129,11 +131,14 @@ class ShellTest extends \PHPUnit\Framework\TestCase
 
     public function testNonInteractiveRawOutput()
     {
-        $config = $this->getConfig(['usePcntl' => false, 'rawOutput' => true]);
+        $config = $this->getConfig([
+            'usePcntl'        => false,
+            'rawOutput'       => true,
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
         $shell = new Shell($config);
 
         $input = $this->getInput('');
-        $input->setInteractive(false);
 
         $output = $this->getOutput();
         $stream = $output->getStream();


### PR DESCRIPTION
This removes an implicit dependency on side effects from command line options, which was caused by name collisions with the base Console Application.

Things like `--verbose` and `--no-interaction` worked ... kind of. But not always (see #621, for example). And when it did work, it's only because both PsySH and the base Applcation were parsing argv and reading the options passed.

Improved plumbing, specifically:
 - When output decoration isn't explicitly specified, check whether stdout is piped.
 - When the interactive mode isn't explicitly specified, detect whether stdin is interactive.

Improved output:
 - Suppress startup messages when output is piped.
 - Write exceptions to stderr (to make it easier to split them off from desired output).
 - Suppress the little newline marker when `--raw` or piping stdout.

New configuration:
- Add interactive mode configuration, update `psy\info()` output.
- Add verbosity configuration, pass it through to ShellOutput.

Improved configuration:
- Clean up color mode config code.
- Move responsibility for command line input overrides into `Configuration::fromInput`
- Move responsibility for input option declarations into `Configuration::getInputOptions`
- Clean up command-line overrides for configuration.
- Make config errors more consistent.

Drive by:
- Add `--ansi` and `--no-ansi` aliases for color cli options (to match Symfony console and Composer).
