### PR TITLE
Add dbg constant

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -105,7 +105,7 @@ class Configuration
     private $interactiveMode = self::INTERACTIVE_MODE_AUTO;
     private $updateCheck;
     private $startupMessage;
-    private $debugConstant = 'SH';
+    private $debugConstant = 'Psy\\sh';
     private $forceArrayIndexes = false;
     private $formatterStyles = [];
     private $verbosity = self::VERBOSITY_NORMAL;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -65,6 +65,7 @@ class Configuration
         'requireSemicolons',
         'runtimeDir',
         'startupMessage',
+        'debugConstant',
         'updateCheck',
         'useBracketedPaste',
         'usePcntl',
@@ -104,6 +105,7 @@ class Configuration
     private $interactiveMode = self::INTERACTIVE_MODE_AUTO;
     private $updateCheck;
     private $startupMessage;
+    private $debugConstant = 'DBG';
     private $forceArrayIndexes = false;
     private $formatterStyles = [];
     private $verbosity = self::VERBOSITY_NORMAL;
@@ -1574,6 +1576,26 @@ class Configuration
     public function setPrompt($prompt)
     {
         $this->prompt = $prompt;
+    }
+
+    /**
+     * Set the debug constant.
+     *
+     * @param string $debugConstant
+     */
+    public function setDebugConstant($debugConstant)
+    {
+        $this->debugConstant = $debugConstant;
+    }
+
+    /**
+     * Get the debug constant.
+     *
+     * @return string
+     */
+    public function getDebugConstant()
+    {
+        return $this->debugConstant;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -105,7 +105,7 @@ class Configuration
     private $interactiveMode = self::INTERACTIVE_MODE_AUTO;
     private $updateCheck;
     private $startupMessage;
-    private $debugConstant = 'DBG';
+    private $debugConstant = 'SH';
     private $forceArrayIndexes = false;
     private $formatterStyles = [];
     private $verbosity = self::VERBOSITY_NORMAL;

--- a/src/functions.php
+++ b/src/functions.php
@@ -396,7 +396,7 @@ EOL;
     }
 }
 
-/**
+/*
  * Use `eval(dbg)` because `eval(\Psy\sh());` is too long
  */
 if (!defined('dbg') && function_exists('Psy\\sh')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -400,5 +400,6 @@ EOL;
  * Use `eval(dbg)` because `eval(\Psy\sh());` is too long
  */
 if (!defined('dbg') && function_exists('Psy\\sh')) {
-    define('dbg', \Psy\sh(), true);
+    $constant = (new Configuration())->getDebugConstant();
+    define($constant, \Psy\sh(), true);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -397,9 +397,9 @@ EOL;
 }
 
 /*
- * Use `eval(dbg)` because `eval(\Psy\sh());` is too long
+ * Use `eval(sh)` because `eval(\Psy\sh());` is too long
  */
-if (!defined('dbg') && function_exists('Psy\\sh')) {
-    $constant = (new Configuration())->getDebugConstant();
+$constant = (new Configuration())->getDebugConstant();
+if (!defined($constant) && function_exists('Psy\\sh')) {
     define($constant, \Psy\sh(), true);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -395,3 +395,10 @@ EOL;
         };
     }
 }
+
+/**
+ * Use `eval(dbg)` because `eval(\Psy\sh());` is too long
+ */
+if (!defined('dbg') && function_exists('Psy\\sh')) {
+    define('dbg', \Psy\sh(), true);
+}


### PR DESCRIPTION
Add a customizable constant to be used instead of a namespaced function

```php
// in config.php
return [
    'debugConstant' => 'DBG' // "\Psy\sh" by default
];
```

```php
// implementation
$foo = "change me";

eval(DBG);
echo $foo;
```