### PR TITLE
Make error message about directory not writable more clear

### DIFF
--- a/src/ConfigPaths.php
+++ b/src/ConfigPaths.php
@@ -214,7 +214,7 @@ class ConfigPaths
         }
 
         if (!\is_dir($dir) || !\is_writable($dir)) {
-            \trigger_error(\sprintf('Writing to %s is not allowed.', $dir), E_USER_NOTICE);
+            \trigger_error(\sprintf('Writing to directory %s is not allowed.', $dir), E_USER_NOTICE);
 
             return false;
         }


### PR DESCRIPTION
Several times faced with error 
![Screenshot from 2020-07-01 11-27-34](https://user-images.githubusercontent.com/9530168/86199919-f6958b80-bb8d-11ea-80f1-539cac884698.png)

when work inside docker and have not enough rights.
And this message made me confused, because i tried create this file  _/var/www/.config/psysh_ and it still didn't work.
I think will be better if add word **directory**