### PR TITLE
New 'completions' command, and various tab-completion fixes and improvements

### DIFF
--- a/src/Command/CompletionsCommand.php
+++ b/src/Command/CompletionsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2020 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Command;
+
+use Psy\Input\CodeArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Dump an array of possible completions for the given input.
+ */
+class CompletionsCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('completions')
+            ->setDefinition([
+                new CodeArgument('target', CodeArgument::OPTIONAL, 'PHP code to complete.'),
+            ])
+            ->setDescription('List possible code completions for the input.')
+            ->setHelp(
+                <<<'HELP'
+This command enables PsySH wrappers to obtain completions for the current
+input, for the purpose of implementing their own completion UI.
+HELP
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $target = $input->getArgument('target');
+        if (!isset($target)) {
+            $target = '';
+        }
+
+        // n.b. All of the relevant parts of \Psy\Shell are protected
+        // or private, so getTabCompletions() itself is a Shell method.
+        $completions = $this->getApplication()->getTabCompletions($target);
+
+        // Ouput the completion candidates as newline-separated text.
+        $str = implode("\n", array_filter($completions))."\n";
+        $output->write($str, false, OutputInterface::OUTPUT_RAW);
+
+        return 0;
+    }
+}

--- a/src/Input/CodeArgument.php
+++ b/src/Input/CodeArgument.php
@@ -26,6 +26,11 @@ use Symfony\Component\Console\Input\InputArgument;
  *     parse function() { return "wheee\n"; }
  *
  * ... without having to put the code in a quoted string and escape everything.
+ *
+ * Certain trailing whitespace characters are exceptions.  Trailing Spaces and
+ * tabs will be included in the argument value, but trailing newlines, carriage
+ * returns, vertical tabs, and nulls are trimmed from the command before the
+ * arguments are established.
  */
 class CodeArgument extends InputArgument
 {

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -926,7 +926,7 @@ class Shell extends Application
             throw new \InvalidArgumentException('Command not found: '.$input);
         }
 
-        $input = new ShellInput(\str_replace('\\', '\\\\', \rtrim($input, " \t\n\r\0\x0B;")));
+        $input = new ShellInput(\str_replace('\\', '\\\\', \rtrim($input, "\n\r\0\x0B;")));
 
         if ($input->hasParameterOption(['--help', '-h'])) {
             $helpCommand = $this->get('help');

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -238,6 +238,23 @@ class Shell extends Application
     }
 
     /**
+     * Get completion matches.
+     *
+     * @return array An array of completion matches for $input
+     */
+    public function getTabCompletions(string $input)
+    {
+        $ac = $this->autoCompleter;
+        $word = '';
+        $regexp = $ac::WORD_REGEXP;
+        $matches = [];
+        if (preg_match($regexp, $input, $matches) === 1) {
+            $word = $matches[0];
+        }
+        return $ac->processCallback($word, null, ['line_buffer' => $input]);
+    }
+
+    /**
      * Gets the default command loop listeners.
      *
      * @return array An array of Execution Loop Listener instances

--- a/src/TabCompletion/AutoCompleter.php
+++ b/src/TabCompletion/AutoCompleter.php
@@ -162,6 +162,9 @@ class AutoCompleter
                 $tokens[] = '';
                 break;
             case AbstractMatcher::tokenIs($token, AbstractMatcher::T_VARIABLE):
+            case $token === '$':
+                // We allow a special case for '$', which for completion
+                // purposes we will treat the same way as T_VARIABLE.
                 $tokens[] = $token;
                 break;
             case !AbstractMatcher::tokenIsValidIdentifier($token):

--- a/src/TabCompletion/AutoCompleter.php
+++ b/src/TabCompletion/AutoCompleter.php
@@ -24,6 +24,84 @@ class AutoCompleter
     protected $matchers;
 
     /**
+     * The set of characters which separate completeable 'words', and
+     * therefore determines the precise $input word for which completion
+     * candidates should be generated (noting that each candidate must
+     * begin with the original $input text).
+     *
+     * PHP's readline support does not provide any control over the
+     * characters which constitute a word break for completion purposes,
+     * which means that we are restricted to the default -- being the
+     * value of GNU Readline's rl_basic_word_break_characters variable:
+     *
+     *   The basic list of characters that signal a break between words
+     *   for the completer routine. The default value of this variable
+     *   is the characters which break words for completion in Bash:
+     *   " \t\n\"\\’‘@$><=;|&{(".
+     *
+     * This limitation has several ramifications for PHP completion:
+     *
+     *  1. The namespace separator '\' introduces a word break, and so
+     *     class name completion is on a per-namespace-component basis.
+     *     When completing a namespaced class, the (incomplete) $input
+     *     parameter (and hence the completion candidates we return) will
+     *     not include the separator or preceding namespace components.
+     *
+     *  2. The double-colon (nekudotayim) operator '::' does NOT introduce
+     *     a word break (as ':' is not a word break character), and so the
+     *     $input parameter will include the preceding 'ClassName::' text
+     *     (typically back to, but not including, a space character or
+     *     namespace-separator '\').  Completion candidates for class
+     *     attributes and methods must therefore include this same prefix.
+     *
+     *  3. The object operator '->' introduces a word break (as '>' is a
+     *     word break character), so when completing an object attribute
+     *     or method, $input will contain only the text following the
+     *     operator, and therefore (unlike '::') the completion candidates
+     *     we return must NOT include the preceding object and operator.
+     *
+     *  4. '$' is a word break character, and so completion for variable
+     *     names does not include the leading '$'.  The $input parameter
+     *     contains only the text following the '$' and therefore the
+     *     candidates we return must do likewise...
+     *
+     *  5. ...Except when we are returning ALL variables (amongst other
+     *     things) as candidates for completing the empty string '', in
+     *     which case we DO need to include the '$' character in each of
+     *     our candidates, because it was not already present in the text.
+     *     (Note that $input will be '' when we are completing either ''
+     *     or '$', so we need to distinguish between those two cases.)
+     *
+     *  6. Only a sub-set of other PHP operators constitute (or end with)
+     *     word breaks, and so inconsistent behaviour can be expected if
+     *     operators are used without surrounding whitespace to ensure a
+     *     word break has occurred.
+     *
+     *     Operators which DO break words include: '>' '<' '<<' '>>' '<>'
+     *     '=' '==' '===' '!=' '!==' '>=' '<=' '<=>' '->' '|' '||' '&' '&&'
+     *     '+=' '-=' '*=' '/=' '.=' '%=' '&=' '|=' '^=' '>>=' '<<=' '??='
+     *
+     *     Operators which do NOT break words include: '!' '+' '-' '*' '/'
+     *     '++' '--' '**' '%' '.' '~' '^' '??' '? :' '::'
+     *
+     *     E.g.: although "foo()+bar()" is valid PHP, we would be unable
+     *     to use completion to obtain the function name "bar" in that
+     *     situation, as the $input string would actually begin with ")+"
+     *     and the Matcher in question would not be returning candidates
+     *     with that prefix.
+     *
+     * @see self::processCallback()
+     * @see \Psy\Shell::getTabCompletions()
+     */
+    public const WORD_BREAK_CHARS = " \t\n\"\\’‘@$><=;|&{(";
+
+    /**
+     * A regular expression based on WORD_BREAK_CHARS which will match the
+     * completable word at the end of the string.
+     */
+    public const WORD_REGEXP = "/[^ \t\n\"\\\\’‘@$><=;|&{(]*$/";
+
+    /**
      * Register a tab completion Matcher.
      *
      * @param AbstractMatcher $matcher
@@ -42,7 +120,13 @@ class AutoCompleter
     }
 
     /**
-     * Handle readline completion.
+     * Handle readline completion for the $input parameter (word).
+     *
+     * @see WORD_BREAK_CHARS
+     *
+     * @TODO: Post-process the completion candidates returned by each
+     * Matcher to ensure that they use the common prefix established by
+     * the $input parameter.
      *
      * @param string $input Readline current word
      * @param int    $index Current word index

--- a/src/TabCompletion/Matcher/AbstractContextAwareMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractContextAwareMatcher.php
@@ -56,10 +56,24 @@ abstract class AbstractContextAwareMatcher extends AbstractMatcher implements Co
     /**
      * Get all variables in the current Context.
      *
+     * @param bool $dollarPrefix
+     *   Whether to prefix '$' to each variable name.
+     *
      * @return array
      */
-    protected function getVariables()
+    protected function getVariables($dollarPrefix = false)
     {
-        return $this->context->getAll();
+        $variables = $this->context->getAll();
+        if (!$dollarPrefix) {
+            return $variables;
+        }
+        else {
+            // Add '$' prefix to each name.
+            $newvars = [];
+            foreach ($variables as $name => $value) {
+                $newvars['$'.$name] = $value;
+            }
+            return $newvars;
+        }
     }
 }

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -45,7 +45,11 @@ abstract class AbstractMatcher
     /**
      * Check whether this matcher can provide completions for $tokens.
      *
-     * @param array $tokens Tokenized readline input
+     * @param array $tokens Tokenized readline input, with whitespace
+     *   tokens removed.  The final token is the identifier prefix to
+     *   be completed (if the input did not end in a valid identifier
+     *   prefix then the final token will be an empty string).  Refer
+     *   to AutoCompleter::processCallback() for details.
      *
      * @return bool
      */
@@ -172,7 +176,7 @@ abstract class AbstractMatcher
      */
     public static function isOperator($token)
     {
-        if (!\is_string($token)) {
+        if (!\is_string($token) || $token === '') {
             return false;
         }
 

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -65,20 +65,19 @@ abstract class AbstractMatcher
      */
     protected function getInput(array $tokens, array $t_valid = null)
     {
-        $var = '';
         $token = \array_pop($tokens);
         $input = \is_array($token) ? $token[1] : $token;
 
         if (isset($t_valid)) {
             if (self::hasToken($t_valid, $token)) {
-                $var = $input;
+                return $input;
             }
         }
         elseif (self::tokenIsValidIdentifier($token, true)) {
-            $var = $input;
+            return $input;
         }
 
-        return $var;
+        return false;
     }
 
     /**

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -171,9 +171,17 @@ abstract class AbstractMatcher
         return \strpos(self::MISC_OPERATORS, $token) !== false;
     }
 
+    /**
+     * Used both to test $tokens[1] (i.e. following T_OPEN_TAG) to
+     * see whether it's a PsySH introspection command, and also by
+     * self::getNamespaceAndClass() to prevent these commands from
+     * being considered part of the namespace (which could happen
+     * on account of all the whitespace tokens having been removed
+     * from the tokens array by AutoCompleter::processCallback().
+     */
     public static function needCompleteClass($token)
     {
-        return \in_array($token[1], ['doc', 'ls', 'show']);
+        return \in_array($token[1], ['doc', 'ls', 'show', 'completions']);
     }
 
     /**

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -58,15 +58,24 @@ abstract class AbstractMatcher
      * Get current readline input word.
      *
      * @param array $tokens Tokenized readline input (see token_get_all)
+     * @param array|null $t_valid Acceptable tokens.  If null then strings
+     *   which are valid identifiers (or empty) are considered valid.
      *
-     * @return string
+     * @return string|bool
      */
-    protected function getInput(array $tokens)
+    protected function getInput(array $tokens, array $t_valid = null)
     {
         $var = '';
-        $firstToken = \array_pop($tokens);
-        if (self::tokenIs($firstToken, self::T_STRING)) {
-            $var = $firstToken[1];
+        $token = \array_pop($tokens);
+        $input = \is_array($token) ? $token[1] : $token;
+
+        if (isset($t_valid)) {
+            if (self::hasToken($t_valid, $token)) {
+                $var = $input;
+            }
+        }
+        elseif (self::tokenIsValidIdentifier($token, true)) {
+            $var = $input;
         }
 
         return $var;

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -93,11 +93,20 @@ abstract class AbstractMatcher
      */
     protected function getNamespaceAndClass($tokens)
     {
-        $class = '';
-        while (self::hasToken(
-            [self::T_NS_SEPARATOR, self::T_STRING],
-            $token = \array_pop($tokens)
-        )) {
+        $validTokens = [
+            self::T_NS_SEPARATOR,
+            self::T_STRING,
+        ];
+
+        $token = \array_pop($tokens);
+        if (!self::hasToken($validTokens, $token)
+            && !self::tokenIsValidIdentifier($token, true))
+        {
+            return '';
+        }
+        $class = \is_array($token) ? $token[1] : $token;
+
+        while (self::hasToken($validTokens, $token = \array_pop($tokens))) {
             if (self::needCompleteClass($token)) {
                 break;
             }

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -116,7 +116,7 @@ abstract class AbstractMatcher
      */
     public static function startsWith($prefix, $word)
     {
-        return \preg_match(\sprintf('#^%s#', $prefix), $word);
+        return \preg_match(\sprintf('#^%s#', \preg_quote($prefix)), $word);
     }
 
     /**

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -172,6 +172,23 @@ abstract class AbstractMatcher
     }
 
     /**
+     * Check whether $token is a valid prefix for a PHP identifier.
+     *
+     * @param mixed $token A PHP token (see token_get_all)
+     * @param bool $allowEmpty Whether an empty string is valid.
+     *
+     * @return bool
+     */
+    public static function tokenIsValidIdentifier($token, bool $allowEmpty = false)
+    {
+        // See AutoCompleter::processCallback() regarding the '' token.
+        if ($token === '') {
+            return $allowEmpty;
+        }
+        return self::hasSyntax($token, self::CONSTANT_SYNTAX);
+    }
+
+    /**
      * Used both to test $tokens[1] (i.e. following T_OPEN_TAG) to
      * see whether it's a PsySH introspection command, and also by
      * self::getNamespaceAndClass() to prevent these commands from

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -201,6 +201,21 @@ abstract class AbstractMatcher
     }
 
     /**
+     * Check whether $token 'separates' PHP expressions, meaning that
+     * whatever follows is a new expression.
+     *
+     * Separators include the initial T_OPEN_TAG token, and ";".
+     *
+     * @param mixed $token A PHP token (see token_get_all)
+     *
+     * @return bool
+     */
+    public static function tokenIsExpressionDelimiter($token)
+    {
+        return $token === ';' || self::tokenIs($token, self::T_OPEN_TAG);
+    }
+
+    /**
      * Used both to test $tokens[1] (i.e. following T_OPEN_TAG) to
      * see whether it's a PsySH introspection command, and also by
      * self::getNamespaceAndClass() to prevent these commands from

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -99,7 +99,7 @@ abstract class AbstractMatcher
             $token = \array_pop($tokens)
         )) {
             if (self::needCompleteClass($token)) {
-                continue;
+                break;
             }
 
             $class = $token[1].$class;

--- a/src/TabCompletion/Matcher/AbstractMatcher.php
+++ b/src/TabCompletion/Matcher/AbstractMatcher.php
@@ -160,11 +160,12 @@ abstract class AbstractMatcher
      */
     public static function tokenIs($token, $which)
     {
-        if (!\is_array($token)) {
-            return false;
+        if (\is_array($token)) {
+            return \token_name($token[0]) === $which;
         }
-
-        return \token_name($token[0]) === $which;
+        else {
+            return $token === $which;
+        }
     }
 
     /**
@@ -238,10 +239,11 @@ abstract class AbstractMatcher
      */
     public static function hasToken(array $coll, $token)
     {
-        if (!\is_array($token)) {
-            return false;
+        if (\is_array($token)) {
+            return \in_array(\token_name($token[0]), $coll);
         }
-
-        return \in_array(\token_name($token[0]), $coll);
+        else {
+            return \in_array($token, $coll, true);
+        }
     }
 }

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -85,6 +85,7 @@ class ClassAttributesMatcher extends AbstractMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '::'.
         switch (true) {
             case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
                 return self::tokenIsValidIdentifier($token, true);

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -86,7 +86,8 @@ class ClassAttributesMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
-            case self::tokenIs($prevToken, self::T_DOUBLE_COLON) && self::tokenIs($token, self::T_STRING):
+            case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
+                return self::tokenIsValidIdentifier($token, true);
             case self::tokenIs($token, self::T_DOUBLE_COLON):
                 return true;
         }

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -52,6 +52,12 @@ class ClassAttributesMatcher extends AbstractMatcher
             \array_keys($reflection->getConstants())
         );
 
+        // We have no control over the word-break characters used by
+        // Readline's completion, and ':' isn't included in that set,
+        // which means the $input which AutoCompleter::processCallback()
+        // is completing includes the preceding "ClassName::" text, and
+        // therefore the candidate strings we are returning must do
+        // likewise.
         return \array_map(
             function ($name) use ($class) {
                 $chunks = \explode('\\', $class);

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -32,10 +32,9 @@ class ClassAttributesMatcher extends AbstractMatcher
         }
 
         $firstToken = \array_pop($tokens);
-        if (self::tokenIs($firstToken, self::T_STRING)) {
-            // second token is the nekudotayim operator
-            \array_pop($tokens);
-        }
+
+        // Second token is the nekudotayim operator '::'.
+        \array_pop($tokens);
 
         $class = $this->getNamespaceAndClass($tokens);
         $chunks = \explode('\\', $class);
@@ -85,8 +84,6 @@ class ClassAttributesMatcher extends AbstractMatcher
         switch (true) {
             case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
                 return self::tokenIsValidIdentifier($token, true);
-            case self::tokenIs($token, self::T_DOUBLE_COLON):
-                return true;
         }
 
         return false;

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -27,6 +27,9 @@ class ClassAttributesMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/ClassAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassAttributesMatcher.php
@@ -38,6 +38,8 @@ class ClassAttributesMatcher extends AbstractMatcher
         }
 
         $class = $this->getNamespaceAndClass($tokens);
+        $chunks = \explode('\\', $class);
+        $className = \array_pop($chunks);
 
         try {
             $reflection = new \ReflectionClass($class);
@@ -62,18 +64,12 @@ class ClassAttributesMatcher extends AbstractMatcher
         // therefore the candidate strings we are returning must do
         // likewise.
         return \array_map(
-            function ($name) use ($class) {
-                $chunks = \explode('\\', $class);
-                $className = \array_pop($chunks);
-
+            function ($name) use ($className) {
                 return $className.'::'.$name;
             },
-            \array_filter(
-                $vars,
-                function ($var) use ($input) {
-                    return AbstractMatcher::startsWith($input, $var);
-                }
-            )
+            \array_filter($vars, function ($var) use ($input) {
+                return AbstractMatcher::startsWith($input, $var);
+            })
         );
     }
 

--- a/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
@@ -52,6 +52,7 @@ class ClassMethodDefaultParametersMatcher extends AbstractDefaultParametersMatch
      */
     public function hasMatched(array $tokens)
     {
+        // Valid following '::METHOD('.
         $openBracket = \array_pop($tokens);
 
         if ($openBracket !== '(') {

--- a/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
@@ -60,7 +60,7 @@ class ClassMethodDefaultParametersMatcher extends AbstractDefaultParametersMatch
 
         $functionName = \array_pop($tokens);
 
-        if (!self::tokenIs($functionName, self::T_STRING)) {
+        if (!self::tokenIsValidIdentifier($functionName)) {
             return false;
         }
 

--- a/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodDefaultParametersMatcher.php
@@ -11,8 +11,16 @@
 
 namespace Psy\TabCompletion\Matcher;
 
+/**
+ * A class method tab completion Matcher.
+ *
+ * This provides completions for all parameters of the specifed method.
+ */
 class ClassMethodDefaultParametersMatcher extends AbstractDefaultParametersMatcher
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getMatches(array $tokens, array $info = [])
     {
         $openBracket = \array_pop($tokens);
@@ -39,6 +47,9 @@ class ClassMethodDefaultParametersMatcher extends AbstractDefaultParametersMatch
         return [];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasMatched(array $tokens)
     {
         $openBracket = \array_pop($tokens);

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -52,6 +52,12 @@ class ClassMethodsMatcher extends AbstractMatcher
             return $method->getName();
         }, $methods);
 
+        // We have no control over the word-break characters used by
+        // Readline's completion, and ':' isn't included in that set,
+        // which means the $input which AutoCompleter::processCallback()
+        // is completing includes the preceding "ClassName::" text, and
+        // therefore the candidate strings we are returning must do
+        // likewise.
         return \array_map(
             function ($name) use ($class) {
                 $chunks = \explode('\\', $class);

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -27,6 +27,9 @@ class ClassMethodsMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -83,7 +83,8 @@ class ClassMethodsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
-            case self::tokenIs($prevToken, self::T_DOUBLE_COLON) && self::tokenIs($token, self::T_STRING):
+            case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
+                return self::tokenIsValidIdentifier($token, true);
             case self::tokenIs($token, self::T_DOUBLE_COLON):
                 return true;
         }

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -38,6 +38,8 @@ class ClassMethodsMatcher extends AbstractMatcher
         }
 
         $class = $this->getNamespaceAndClass($tokens);
+        $chunks = \explode('\\', $class);
+        $className = \array_pop($chunks);
 
         try {
             $reflection = new \ReflectionClass($class);
@@ -62,10 +64,7 @@ class ClassMethodsMatcher extends AbstractMatcher
         // therefore the candidate strings we are returning must do
         // likewise.
         return \array_map(
-            function ($name) use ($class) {
-                $chunks = \explode('\\', $class);
-                $className = \array_pop($chunks);
-
+            function ($name) use ($className) {
                 return $className.'::'.$name;
             },
             \array_filter($methods, function ($method) use ($input) {

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -82,6 +82,7 @@ class ClassMethodsMatcher extends AbstractMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '::'.
         switch (true) {
             case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
                 return self::tokenIsValidIdentifier($token, true);

--- a/src/TabCompletion/Matcher/ClassMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ClassMethodsMatcher.php
@@ -32,10 +32,9 @@ class ClassMethodsMatcher extends AbstractMatcher
         }
 
         $firstToken = \array_pop($tokens);
-        if (self::tokenIs($firstToken, self::T_STRING)) {
-            // second token is the nekudotayim operator
-            \array_pop($tokens);
-        }
+
+        // Second token is the nekudotayim operator '::'.
+        \array_pop($tokens);
 
         $class = $this->getNamespaceAndClass($tokens);
         $chunks = \explode('\\', $class);
@@ -85,8 +84,6 @@ class ClassMethodsMatcher extends AbstractMatcher
         switch (true) {
             case self::tokenIs($prevToken, self::T_DOUBLE_COLON):
                 return self::tokenIsValidIdentifier($token, true);
-            case self::tokenIs($token, self::T_DOUBLE_COLON):
-                return true;
         }
 
         return false;

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -60,8 +60,7 @@ class ClassNamesMatcher extends AbstractMatcher
         ];
 
         switch (true) {
-            // Blacklisted.
-            case self::hasToken([$blacklistedTokens], $token):
+            // Previous token (blacklist).
             case self::hasToken([$blacklistedTokens], $prevToken):
             case $token === '$':
                 return false;
@@ -69,8 +68,7 @@ class ClassNamesMatcher extends AbstractMatcher
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $prevToken):
                 return self::tokenIsValidIdentifier($token, true);
             // Current token (whitelist).
-            case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $token):
-            case self::isOperator($token):
+            case self::tokenIsValidIdentifier($token, true):
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -64,7 +64,8 @@ class ClassNamesMatcher extends AbstractMatcher
             case self::hasToken([$blacklistedTokens], $prevToken):
             case \is_string($token) && $token === '$':
                 return false;
-            case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR, self::T_STRING], $prevToken):
+            case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $prevToken):
+                return self::tokenIsValidIdentifier($token, true);
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $token):
             case self::isOperator($token):
                 return true;

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -60,12 +60,15 @@ class ClassNamesMatcher extends AbstractMatcher
         ];
 
         switch (true) {
+            // Blacklisted.
             case self::hasToken([$blacklistedTokens], $token):
             case self::hasToken([$blacklistedTokens], $prevToken):
             case \is_string($token) && $token === '$':
                 return false;
+            // Previous token.
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $prevToken):
                 return self::tokenIsValidIdentifier($token, true);
+            // Current token (whitelist).
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $token):
             case self::isOperator($token):
                 return true;

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -54,14 +54,20 @@ class ClassNamesMatcher extends AbstractMatcher
     {
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
-
-        $blacklistedTokens = [
-            self::T_INCLUDE, self::T_INCLUDE_ONCE, self::T_REQUIRE, self::T_REQUIRE_ONCE,
+        $prevTokenBlacklist = [
+            self::T_INCLUDE,
+            self::T_INCLUDE_ONCE,
+            self::T_REQUIRE,
+            self::T_REQUIRE_ONCE,
+            self::T_OBJECT_OPERATOR,
+            self::T_DOUBLE_COLON,
         ];
 
         switch (true) {
             // Previous token (blacklist).
-            case self::hasToken([$blacklistedTokens], $prevToken):
+            case self::hasToken($prevTokenBlacklist, $prevToken):
+                return false;
+            // Current token (blacklist).
             case $token === '$':
                 return false;
             // Previous token.

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -29,7 +29,6 @@ class ClassNamesMatcher extends AbstractMatcher
         if (\strlen($class) > 0 && $class[0] === '\\') {
             $class = \substr($class, 1, \strlen($class));
         }
-        $quotedClass = \preg_quote($class);
 
         return \array_map(
             function ($className) use ($class) {
@@ -41,8 +40,8 @@ class ClassNamesMatcher extends AbstractMatcher
             },
             \array_filter(
                 \array_merge(\get_declared_classes(), \get_declared_interfaces()),
-                function ($className) use ($quotedClass) {
-                    return AbstractMatcher::startsWith($quotedClass, $className);
+                function ($className) use ($class) {
+                    return AbstractMatcher::startsWith($class, $className);
                 }
             )
         );

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -66,7 +66,6 @@ class ClassNamesMatcher extends AbstractMatcher
                 return false;
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR, self::T_STRING], $prevToken):
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $token):
-            case self::hasToken([self::T_OPEN_TAG, self::T_VARIABLE], $token):
             case self::isOperator($token):
                 return true;
         }

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -63,7 +63,7 @@ class ClassNamesMatcher extends AbstractMatcher
             // Blacklisted.
             case self::hasToken([$blacklistedTokens], $token):
             case self::hasToken([$blacklistedTokens], $prevToken):
-            case \is_string($token) && $token === '$':
+            case $token === '$':
                 return false;
             // Previous token.
             case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $prevToken):

--- a/src/TabCompletion/Matcher/ClassNamesMatcher.php
+++ b/src/TabCompletion/Matcher/ClassNamesMatcher.php
@@ -65,7 +65,8 @@ class ClassNamesMatcher extends AbstractMatcher
             case $token === '$':
                 return false;
             // Previous token.
-            case self::hasToken([self::T_NEW, self::T_OPEN_TAG, self::T_NS_SEPARATOR], $prevToken):
+            case self::tokenIsExpressionDelimiter($prevToken):
+            case self::hasToken([self::T_NEW, self::T_NS_SEPARATOR], $prevToken):
                 return self::tokenIsValidIdentifier($token, true);
             // Current token (whitelist).
             case self::tokenIsValidIdentifier($token, true):

--- a/src/TabCompletion/Matcher/CommandsMatcher.php
+++ b/src/TabCompletion/Matcher/CommandsMatcher.php
@@ -106,6 +106,7 @@ class CommandsMatcher extends AbstractMatcher
 
         // Valid for completion only if this was the only token.
         switch (true) {
+            case empty($command):
             case empty($tokens) &&
                 self::tokenIsValidIdentifier($command, true) &&
                 $this->matchCommand($command[1]):

--- a/src/TabCompletion/Matcher/CommandsMatcher.php
+++ b/src/TabCompletion/Matcher/CommandsMatcher.php
@@ -106,7 +106,7 @@ class CommandsMatcher extends AbstractMatcher
 
         switch (true) {
             case empty($tokens) &&
-                self::tokenIs($command, self::T_STRING) &&
+                self::tokenIsValidIdentifier($command, true) &&
                 $this->matchCommand($command[1]):
                 return true;
         }

--- a/src/TabCompletion/Matcher/CommandsMatcher.php
+++ b/src/TabCompletion/Matcher/CommandsMatcher.php
@@ -87,6 +87,9 @@ class CommandsMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         return \array_filter($this->commands, function ($command) use ($input) {
             return AbstractMatcher::startsWith($input, $command);

--- a/src/TabCompletion/Matcher/CommandsMatcher.php
+++ b/src/TabCompletion/Matcher/CommandsMatcher.php
@@ -105,10 +105,9 @@ class CommandsMatcher extends AbstractMatcher
         $command = \array_shift($tokens);
 
         switch (true) {
-            case self::tokenIs($command, self::T_STRING) &&
-                !$this->isCommand($command[1]) &&
-                $this->matchCommand($command[1]) &&
-                empty($tokens):
+            case empty($tokens) &&
+                self::tokenIs($command, self::T_STRING) &&
+                $this->matchCommand($command[1]):
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/CommandsMatcher.php
+++ b/src/TabCompletion/Matcher/CommandsMatcher.php
@@ -104,6 +104,7 @@ class CommandsMatcher extends AbstractMatcher
         /* $openTag */ \array_shift($tokens);
         $command = \array_shift($tokens);
 
+        // Valid for completion only if this was the only token.
         switch (true) {
             case empty($tokens) &&
                 self::tokenIsValidIdentifier($command, true) &&

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -25,10 +25,10 @@ class ConstantsMatcher extends AbstractMatcher
      */
     public function getMatches(array $tokens, array $info = [])
     {
-        $const = $this->getInput($tokens);
+        $input = $this->getInput($tokens);
 
-        return \array_filter(\array_keys(\get_defined_constants()), function ($constant) use ($const) {
-            return AbstractMatcher::startsWith($const, $constant);
+        return \array_filter(\array_keys(\get_defined_constants()), function ($constant) use ($input) {
+            return AbstractMatcher::startsWith($input, $constant);
         });
     }
 

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -44,9 +44,11 @@ class ConstantsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
+            // Previous token (blacklist).
             case self::tokenIs($prevToken, self::T_NEW):
             case self::tokenIs($prevToken, self::T_NS_SEPARATOR):
                 return false;
+            // Current token (whitelist).
             case self::tokenIs($token, self::T_OPEN_TAG):
             case self::isOperator($token):
             case self::tokenIsValidIdentifier($token, true);

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -42,11 +42,16 @@ class ConstantsMatcher extends AbstractMatcher
     {
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
+        $prevTokenBlacklist = [
+            self::T_NEW,
+            self::T_NS_SEPARATOR,
+            self::T_OBJECT_OPERATOR,
+            self::T_DOUBLE_COLON,
+        ];
 
         switch (true) {
             // Previous token (blacklist).
-            case self::tokenIs($prevToken, self::T_NEW):
-            case self::tokenIs($prevToken, self::T_NS_SEPARATOR):
+            case self::hasToken($prevTokenBlacklist, $prevToken):
                 return false;
             // Current token (whitelist).
             case self::tokenIsValidIdentifier($token, true);

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -49,8 +49,6 @@ class ConstantsMatcher extends AbstractMatcher
             case self::tokenIs($prevToken, self::T_NS_SEPARATOR):
                 return false;
             // Current token (whitelist).
-            case self::tokenIs($token, self::T_OPEN_TAG):
-            case self::isOperator($token):
             case self::tokenIsValidIdentifier($token, true);
                 return true;
         }

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -47,8 +47,9 @@ class ConstantsMatcher extends AbstractMatcher
             case self::tokenIs($prevToken, self::T_NEW):
             case self::tokenIs($prevToken, self::T_NS_SEPARATOR):
                 return false;
-            case self::hasToken([self::T_OPEN_TAG, self::T_STRING], $token):
+            case self::tokenIs($token, self::T_OPEN_TAG):
             case self::isOperator($token):
+            case self::tokenIsValidIdentifier($token, true);
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/ConstantsMatcher.php
+++ b/src/TabCompletion/Matcher/ConstantsMatcher.php
@@ -26,6 +26,9 @@ class ConstantsMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         return \array_filter(\array_keys(\get_defined_constants()), function ($constant) use ($input) {
             return AbstractMatcher::startsWith($input, $constant);

--- a/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
@@ -51,7 +51,7 @@ class FunctionDefaultParametersMatcher extends AbstractDefaultParametersMatcher
 
         $functionName = \array_pop($tokens);
 
-        if (!self::tokenIs($functionName, self::T_STRING)) {
+        if (!self::tokenIsValidIdentifier($functionName)) {
             return false;
         }
 

--- a/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
@@ -11,8 +11,16 @@
 
 namespace Psy\TabCompletion\Matcher;
 
+/**
+ * A function parameter tab completion Matcher.
+ *
+ * This provides completions for all parameters of the specifed function.
+ */
 class FunctionDefaultParametersMatcher extends AbstractDefaultParametersMatcher
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getMatches(array $tokens, array $info = [])
     {
         \array_pop($tokens); // open bracket
@@ -30,6 +38,9 @@ class FunctionDefaultParametersMatcher extends AbstractDefaultParametersMatcher
         return $this->getDefaultParameterCompletion($parameters);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasMatched(array $tokens)
     {
         $openBracket = \array_pop($tokens);

--- a/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionDefaultParametersMatcher.php
@@ -43,6 +43,7 @@ class FunctionDefaultParametersMatcher extends AbstractDefaultParametersMatcher
      */
     public function hasMatched(array $tokens)
     {
+        // Valid following 'FUNCTION('.
         $openBracket = \array_pop($tokens);
 
         if ($openBracket !== '(') {

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -45,10 +45,16 @@ class FunctionsMatcher extends AbstractMatcher
     {
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
+        $prevTokenBlacklist = [
+            self::T_NEW,
+            self::T_NS_SEPARATOR,
+            self::T_OBJECT_OPERATOR,
+            self::T_DOUBLE_COLON,
+        ];
 
         switch (true) {
             // Previous token (blacklist).
-            case self::tokenIs($prevToken, self::T_NEW):
+            case self::hasToken($prevTokenBlacklist, $prevToken):
                 return false;
             // Current token (whitelist).
             case self::tokenIsValidIdentifier($token, true):

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -47,8 +47,10 @@ class FunctionsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
+            // Previous token (blacklist).
             case self::tokenIs($prevToken, self::T_NEW):
                 return false;
+            // Current token (whitelist).
             case self::hasToken([self::T_OPEN_TAG], $token):
             case self::isOperator($token):
             case self::tokenIsValidIdentifier($token, true):

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -26,6 +26,9 @@ class FunctionsMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $functions = \get_defined_functions();
         $allFunctions = \array_merge($functions['user'], $functions['internal']);

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -25,13 +25,13 @@ class FunctionsMatcher extends AbstractMatcher
      */
     public function getMatches(array $tokens, array $info = [])
     {
-        $func = $this->getInput($tokens);
+        $input = $this->getInput($tokens);
 
         $functions = \get_defined_functions();
         $allFunctions = \array_merge($functions['user'], $functions['internal']);
 
-        return \array_filter($allFunctions, function ($function) use ($func) {
-            return AbstractMatcher::startsWith($func, $function);
+        return \array_filter($allFunctions, function ($function) use ($input) {
+            return AbstractMatcher::startsWith($input, $function);
         });
     }
 

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -51,8 +51,6 @@ class FunctionsMatcher extends AbstractMatcher
             case self::tokenIs($prevToken, self::T_NEW):
                 return false;
             // Current token (whitelist).
-            case self::hasToken([self::T_OPEN_TAG], $token):
-            case self::isOperator($token):
             case self::tokenIsValidIdentifier($token, true):
                 return true;
         }

--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -49,8 +49,9 @@ class FunctionsMatcher extends AbstractMatcher
         switch (true) {
             case self::tokenIs($prevToken, self::T_NEW):
                 return false;
-            case self::hasToken([self::T_OPEN_TAG, self::T_STRING], $token):
+            case self::hasToken([self::T_OPEN_TAG], $token):
             case self::isOperator($token):
+            case self::tokenIsValidIdentifier($token, true):
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -73,8 +73,17 @@ class KeywordsMatcher extends AbstractMatcher
     {
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
+        $prevTokenBlacklist = [
+            self::T_NEW,
+            self::T_NS_SEPARATOR,
+            self::T_OBJECT_OPERATOR,
+            self::T_DOUBLE_COLON,
+        ];
 
         switch (true) {
+            // Previous token (blacklist).
+            case self::hasToken($prevTokenBlacklist, $prevToken):
+                return false;
             // Previous token.
             case self::tokenIsExpressionDelimiter($prevToken):
                 return self::tokenIsValidIdentifier($token, true);

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -57,6 +57,9 @@ class KeywordsMatcher extends AbstractMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         return \array_filter($this->keywords, function ($keyword) use ($input) {
             return AbstractMatcher::startsWith($input, $keyword);

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -76,7 +76,7 @@ class KeywordsMatcher extends AbstractMatcher
 
         switch (true) {
             // Previous token.
-            case self::tokenIs($prevToken, self::T_OPEN_TAG):
+            case self::tokenIsExpressionDelimiter($prevToken):
                 return self::tokenIsValidIdentifier($token, true);
             // Current token (whitelist).
             case self::tokenIsValidIdentifier($token, true):

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -75,10 +75,8 @@ class KeywordsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
-            case self::hasToken([self::T_OPEN_TAG, self::T_VARIABLE], $token):
-//            case is_string($token) && $token === '$':
-            case self::hasToken([self::T_OPEN_TAG, self::T_VARIABLE], $prevToken) &&
-                self::tokenIs($token, self::T_STRING):
+            case self::tokenIs($token, self::T_OPEN_TAG):
+            case self::tokenIs($prevToken, self::T_OPEN_TAG) && self::tokenIs($token, self::T_STRING):
             case self::isOperator($token):
                 return true;
         }

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -75,8 +75,10 @@ class KeywordsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
+            // Previous token.
             case self::tokenIs($prevToken, self::T_OPEN_TAG):
                 return self::tokenIsValidIdentifier($token, true);
+            // Current token (whitelist).
             case self::tokenIs($token, self::T_OPEN_TAG):
             case self::isOperator($token):
                 return true;

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -79,8 +79,7 @@ class KeywordsMatcher extends AbstractMatcher
             case self::tokenIs($prevToken, self::T_OPEN_TAG):
                 return self::tokenIsValidIdentifier($token, true);
             // Current token (whitelist).
-            case self::tokenIs($token, self::T_OPEN_TAG):
-            case self::isOperator($token):
+            case self::tokenIsValidIdentifier($token, true):
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/KeywordsMatcher.php
+++ b/src/TabCompletion/Matcher/KeywordsMatcher.php
@@ -75,8 +75,9 @@ class KeywordsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
+            case self::tokenIs($prevToken, self::T_OPEN_TAG):
+                return self::tokenIsValidIdentifier($token, true);
             case self::tokenIs($token, self::T_OPEN_TAG):
-            case self::tokenIs($prevToken, self::T_OPEN_TAG) && self::tokenIs($token, self::T_STRING):
             case self::isOperator($token):
                 return true;
         }

--- a/src/TabCompletion/Matcher/MongoClientMatcher.php
+++ b/src/TabCompletion/Matcher/MongoClientMatcher.php
@@ -65,8 +65,6 @@ class MongoClientMatcher extends AbstractContextAwareMatcher
 
         // Valid following '->'.
         switch (true) {
-            case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-                return true;
             case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return self::tokenIsValidIdentifier($token, true);
         }

--- a/src/TabCompletion/Matcher/MongoClientMatcher.php
+++ b/src/TabCompletion/Matcher/MongoClientMatcher.php
@@ -63,6 +63,7 @@ class MongoClientMatcher extends AbstractContextAwareMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '->'.
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
                 return true;

--- a/src/TabCompletion/Matcher/MongoClientMatcher.php
+++ b/src/TabCompletion/Matcher/MongoClientMatcher.php
@@ -26,6 +26,9 @@ class MongoClientMatcher extends AbstractContextAwareMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/MongoClientMatcher.php
+++ b/src/TabCompletion/Matcher/MongoClientMatcher.php
@@ -65,8 +65,9 @@ class MongoClientMatcher extends AbstractContextAwareMatcher
 
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return true;
+            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
+                return self::tokenIsValidIdentifier($token, true);
         }
 
         return false;

--- a/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
+++ b/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
@@ -26,6 +26,9 @@ class MongoDatabaseMatcher extends AbstractContextAwareMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
+++ b/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
@@ -61,8 +61,9 @@ class MongoDatabaseMatcher extends AbstractContextAwareMatcher
 
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return true;
+            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
+                return self::tokenIsValidIdentifier($token, true);
         }
 
         return false;

--- a/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
+++ b/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
@@ -59,6 +59,7 @@ class MongoDatabaseMatcher extends AbstractContextAwareMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '->'.
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
                 return true;

--- a/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
+++ b/src/TabCompletion/Matcher/MongoDatabaseMatcher.php
@@ -61,8 +61,6 @@ class MongoDatabaseMatcher extends AbstractContextAwareMatcher
 
         // Valid following '->'.
         switch (true) {
-            case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-                return true;
             case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return self::tokenIsValidIdentifier($token, true);
         }

--- a/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -34,10 +34,10 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
         }
 
         $firstToken = \array_pop($tokens);
-        if (self::tokenIs($firstToken, self::T_STRING)) {
-            // second token is the object operator
-            \array_pop($tokens);
-        }
+
+        // Second token is the object operator '->'.
+        \array_pop($tokens);
+
         $objectToken = \array_pop($tokens);
         if (!\is_array($objectToken)) {
             return [];
@@ -72,8 +72,6 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
 
         // Valid following '->'.
         switch (true) {
-            case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-                return true;
             case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return self::tokenIsValidIdentifier($token, true);
         }

--- a/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -72,8 +72,9 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
 
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return true;
+            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
+                return self::tokenIsValidIdentifier($token, true);
         }
 
         return false;

--- a/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -29,6 +29,9 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectAttributesMatcher.php
@@ -70,6 +70,7 @@ class ObjectAttributesMatcher extends AbstractContextAwareMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '->'.
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
                 return true;

--- a/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
@@ -11,8 +11,16 @@
 
 namespace Psy\TabCompletion\Matcher;
 
+/**
+ * An object method parameter tab completion Matcher.
+ *
+ * This provides completions for all parameters of the specifed method.
+ */
 class ObjectMethodDefaultParametersMatcher extends AbstractDefaultParametersMatcher
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getMatches(array $tokens, array $info = [])
     {
         $openBracket = \array_pop($tokens);
@@ -46,6 +54,9 @@ class ObjectMethodDefaultParametersMatcher extends AbstractDefaultParametersMatc
         return [];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasMatched(array $tokens)
     {
         $openBracket = \array_pop($tokens);

--- a/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
@@ -67,7 +67,7 @@ class ObjectMethodDefaultParametersMatcher extends AbstractDefaultParametersMatc
 
         $functionName = \array_pop($tokens);
 
-        if (!self::tokenIs($functionName, self::T_STRING)) {
+        if (!self::tokenIsValidIdentifier($functionName)) {
             return false;
         }
 

--- a/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodDefaultParametersMatcher.php
@@ -59,6 +59,7 @@ class ObjectMethodDefaultParametersMatcher extends AbstractDefaultParametersMatc
      */
     public function hasMatched(array $tokens)
     {
+        // Valid following '->METHOD('.
         $openBracket = \array_pop($tokens);
 
         if ($openBracket !== '(') {

--- a/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -29,6 +29,9 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = $this->getInput($tokens);
+        if ($input === false) {
+            return [];
+        }
 
         $firstToken = \array_pop($tokens);
         if (self::tokenIs($firstToken, self::T_STRING)) {

--- a/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -74,8 +74,9 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
 
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return true;
+            case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
+                return self::tokenIsValidIdentifier($token, true);
         }
 
         return false;

--- a/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -34,10 +34,10 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
         }
 
         $firstToken = \array_pop($tokens);
-        if (self::tokenIs($firstToken, self::T_STRING)) {
-            // second token is the object operator
-            \array_pop($tokens);
-        }
+
+        // Second token is the object operator '->'.
+        \array_pop($tokens);
+
         $objectToken = \array_pop($tokens);
         if (!\is_array($objectToken)) {
             return [];
@@ -74,8 +74,6 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
 
         // Valid following '->'.
         switch (true) {
-            case self::tokenIs($token, self::T_OBJECT_OPERATOR):
-                return true;
             case self::tokenIs($prevToken, self::T_OBJECT_OPERATOR):
                 return self::tokenIsValidIdentifier($token, true);
         }

--- a/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
+++ b/src/TabCompletion/Matcher/ObjectMethodsMatcher.php
@@ -72,6 +72,7 @@ class ObjectMethodsMatcher extends AbstractContextAwareMatcher
         $token = \array_pop($tokens);
         $prevToken = \array_pop($tokens);
 
+        // Valid following '->'.
         switch (true) {
             case self::tokenIs($token, self::T_OBJECT_OPERATOR):
                 return true;

--- a/src/TabCompletion/Matcher/VariablesMatcher.php
+++ b/src/TabCompletion/Matcher/VariablesMatcher.php
@@ -43,9 +43,8 @@ class VariablesMatcher extends AbstractContextAwareMatcher
         $token = \array_pop($tokens);
 
         switch (true) {
-            case self::hasToken([self::T_OPEN_TAG, self::T_VARIABLE], $token):
-            case $token === '$':
-            case self::isOperator($token):
+            case self::tokenIs($token, self::T_VARIABLE):
+            case in_array($token, ['', '$'], true):
                 return true;
         }
 

--- a/src/TabCompletion/Matcher/VariablesMatcher.php
+++ b/src/TabCompletion/Matcher/VariablesMatcher.php
@@ -44,7 +44,7 @@ class VariablesMatcher extends AbstractContextAwareMatcher
 
         switch (true) {
             case self::hasToken([self::T_OPEN_TAG, self::T_VARIABLE], $token):
-            case \is_string($token) && $token === '$':
+            case $token === '$':
             case self::isOperator($token):
                 return true;
         }

--- a/src/TabCompletion/Matcher/VariablesMatcher.php
+++ b/src/TabCompletion/Matcher/VariablesMatcher.php
@@ -26,6 +26,9 @@ class VariablesMatcher extends AbstractContextAwareMatcher
     public function getMatches(array $tokens, array $info = [])
     {
         $input = \str_replace('$', '', $this->getInput($tokens));
+        if ($input === false) {
+            return [];
+        }
 
         return \array_filter(\array_keys($this->getVariables()), function ($variable) use ($input) {
             return AbstractMatcher::startsWith($input, $variable);

--- a/src/TabCompletion/Matcher/VariablesMatcher.php
+++ b/src/TabCompletion/Matcher/VariablesMatcher.php
@@ -25,10 +25,10 @@ class VariablesMatcher extends AbstractContextAwareMatcher
      */
     public function getMatches(array $tokens, array $info = [])
     {
-        $var = \str_replace('$', '', $this->getInput($tokens));
+        $input = \str_replace('$', '', $this->getInput($tokens));
 
-        return \array_filter(\array_keys($this->getVariables()), function ($variable) use ($var) {
-            return AbstractMatcher::startsWith($var, $variable);
+        return \array_filter(\array_keys($this->getVariables()), function ($variable) use ($input) {
+            return AbstractMatcher::startsWith($input, $variable);
         });
     }
 

--- a/src/TabCompletion/Matcher/VariablesMatcher.php
+++ b/src/TabCompletion/Matcher/VariablesMatcher.php
@@ -65,8 +65,19 @@ class VariablesMatcher extends AbstractContextAwareMatcher
     public function hasMatched(array $tokens)
     {
         $token = \array_pop($tokens);
+        $prevToken = \array_pop($tokens);
+        $prevTokenBlacklist = [
+            self::T_NEW,
+            self::T_NS_SEPARATOR,
+            self::T_OBJECT_OPERATOR,
+            self::T_DOUBLE_COLON,
+        ];
 
         switch (true) {
+            // Previous token (blacklist).
+            case self::hasToken($prevTokenBlacklist, $prevToken):
+                return false;
+            // Current token (whitelist).
             case self::tokenIs($token, self::T_VARIABLE):
             case in_array($token, ['', '$'], true):
                 return true;


### PR DESCRIPTION
This branch implements the new command `completions` for issue #555,
and also fixes most of the pre-existing problems I encountered while testing
the command and my wrapper.  The fixes may well resolve some of the other
tab-completion issues which have been raised previously.

The command is not enabled by default; I'm enabling it in my config file by setting:

```php
  // Make the 'completions' command available.
  'commands' => class_exists('\Psy\Command\CompletionsCommand')
    ? [ new \Psy\Command\CompletionsCommand, ]
    : [],
```

There are plenty of changes here, but I've kept the individual commits
very focused, so hopefully it's all fairly easy to review.

----

The `Psy\TabCompletion\Matcher` systems are doing smart things with PHP
tokens, but are also regularly getting tripped up by them and failing to
offer any completions at all (while sometimes simultaneously treating huge
numbers of irrelevant thing as completion options in the background).

The completion process starts with:

```php
$tokens = \token_get_all('<?php ' . $line);
```

And then generally the last token is popped from the array and checked to
see whether it could be a valid token for that Matcher's interests, and the
problem is that these tests consider a *very* limited set of tokens, which
then excludes the large number of PHP keywords which (a) have their own
token, and (b) are completely valid prefixes for an as-yet *incomplete*
identifier.

So for instance, if you defined a function `abstraction()` and then try to
use tab completion to input that name, you can complete from "abstrac" and
"abstracti", but "abstract" gives you no results, because that's the token
`T_ABSTRACT`, and `FunctionsMatcher::hasMatched()`, like most of the
matchers, ignores text which wasn't parsed as `T_STRING`.

I think the following would be the current list of un-completable
identifiers, but obviously it's subject to change as the language evolves,
so maintaining a big whitelist doesn't seem like the way forward.

```
T_ABSTRACT                      abstract
T_LOGICAL_AND                   and
T_ARRAY                         array
T_AS                            as
T_BREAK                         break
T_CALLABLE                      callable
T_CASE                          case
T_CATCH                         catch
T_CLASS                         class
T_CLONE                         clone
T_CONST                         const
T_CONTINUE                      continue
T_DECLARE                       declare
T_DEFAULT                       default
T_EXIT                          die
T_DO                            do
T_ECHO                          echo
T_ELSE                          else
T_ELSEIF                        elseif
T_EMPTY                         empty
T_ENDDECLARE                    enddeclare
T_ENDFOR                        endfor
T_ENDFOREACH                    endforeach
T_ENDIF                         endif
T_ENDSWITCH                     endswitch
T_ENDWHILE                      endwhile
T_EVAL                          eval
T_EXIT                          exit
T_EXTENDS                       extends
T_FINAL                         final
T_FINALLY                       finally
T_FN                            fn
T_FOR                           for
T_FOREACH                       foreach
T_FUNCTION                      function
T_GLOBAL                        global
T_GOTO                          goto
T_IF                            if
T_IMPLEMENTS                    implements
T_INCLUDE                       include
T_INCLUDE_ONCE                  include_once
T_INSTANCEOF                    instanceof
T_INSTEADOF                     insteadof
T_INTERFACE                     interface
T_ISSET                         isset
T_LIST                          list
T_NAMESPACE                     namespace
T_NEW                           new
T_LOGICAL_OR                    or
T_PRINT                         print
T_PRIVATE                       private
T_PROTECTED                     protected
T_PUBLIC                        public
T_REQUIRE                       require
T_REQUIRE_ONCE                  require_once
T_RETURN                        return
T_STATIC                        static
T_SWITCH                        switch
T_THROW                         throw
T_TRAIT                         trait
T_TRY                           try
T_UNSET                         unset
T_USE                           use
T_VAR                           var
T_WHILE                         while
T_LOGICAL_XOR                   xor
T_YIELD                         yield
```

That's 67 tokens (which is nearly 50%).  The remaining 72 are:

```
T_AND_EQUAL                     &=
T_ARRAY_CAST                    (array)
T_BAD_CHARACTER
T_BOOLEAN_AND                   &&
T_BOOLEAN_OR                    ||
T_BOOL_CAST                     (bool) or (boolean)
T_CHARACTER
T_CLASS_C                       __CLASS__
T_CLOSE_TAG                     ?> or %>
T_COALESCE                      ??
T_COALESCE_EQUAL                ??=
T_COMMENT                       // or #, and /* */
T_CONCAT_EQUAL                  .=
T_CONSTANT_ENCAPSED_STRING      "foo" or 'bar'
T_CURLY_OPEN                    {$
T_DEC                           --
T_DIR                           __DIR__
T_DIV_EQUAL                     /=
T_DNUMBER                       0.12, etc.
T_DOC_COMMENT                   /** */
T_DOLLAR_OPEN_CURLY_BRACES      ${
T_DOUBLE_ARROW                  =>
T_DOUBLE_CAST                   (real), (double) or (float)
T_DOUBLE_COLON                  ::
T_ELLIPSIS                      ...
T_ENCAPSED_AND_WHITESPACE       " $a"
T_END_HEREDOC
T_FILE                          __FILE__
T_FUNC_C                        __FUNCTION__
T_HALT_COMPILER                 __halt_compiler
T_INC                           ++
T_INLINE_HTML
T_INT_CAST                      (int) or (integer)
T_IS_EQUAL                      ==
T_IS_GREATER_OR_EQUAL           >=
T_IS_IDENTICAL                  ===
T_IS_NOT_EQUAL                  != or <>
T_IS_NOT_IDENTICAL              !==
T_IS_SMALLER_OR_EQUAL           <=
T_LINE                          __LINE__
T_LNUMBER                       123, 012, 0x1ac, etc.
T_METHOD_C                      __METHOD__
T_MINUS_EQUAL                   -=
T_MOD_EQUAL                     %=
T_MUL_EQUAL                     *=
T_NS_C                          __NAMESPACE__
T_NS_SEPARATOR                  \
T_NUM_STRING                    "$a[0]"
T_OBJECT_CAST                   (object)
T_OBJECT_OPERATOR               ->
T_OPEN_TAG                      <?php, <? or <%
T_OPEN_TAG_WITH_ECHO            <?= or <%=
T_OR_EQUAL                      |=
T_PAAMAYIM_NEKUDOTAYIM          ::
T_PLUS_EQUAL                    +=
T_POW                           **
T_POW_EQUAL                     **=
T_SL                            <<
T_SL_EQUAL                      <<=
T_SPACESHIP                     <=>
T_SR                            >>
T_SR_EQUAL                      >>=
T_START_HEREDOC                 <<<
T_STRING                        parent, self, etc.
T_STRING_CAST                   (string)
T_STRING_VARNAME                "${a
T_TRAIT_C                       __TRAIT__
T_UNSET_CAST                    (unset)
T_VARIABLE                      $foo
T_WHITESPACE                    \t \r\n
T_XOR_EQUAL                     ^=
T_YIELD_FROM                    yield from
```

We need all the Matchers to stop caring whether or not the last token in the
list was parsed as `T_STRING` (in particular), because implicitly that token
is not yet complete, and therefore the parser can't know what it's
*supposed* to be.  They should ignore the token type, and instead just check
that text to see whether it would be valid as the prefix of an identifier,
which we can do by matching against the `CONSTANT_SYNTAX` regexp[1].

----

In addition to the bug where *no* completions are supplied, the token
behaviour can also do something akin to the opposite, and cause certain
matchers to return *everything they know about* as a completion, whether or
not it matches the initial input.

This happens when a matcher's `getMatches()` method calls
`AbstractMatcher::getInput()` which firstly sets `$var` to an empty string,
but then (on account of tokens) never gets to change it to anything else.

`getMatches()` then 'filters' All Of The Things It Knows About using
`AbstractMatcher::startsWith()`, to find which of those things begins with
an empty string.  That method happily agrees that *everything* starts with
an empty string, and so All Of The Things are merged into the set of
completions.

You can observe this by adding `print_r($matches);` (or other logging) to
`AutoCompleter::processCallback()` right before it returns, and then
attempting completion.  `var` or `$var` for example.

GNU Readline is masking this bug by not presenting any of the candidates
which do not actually start with the original incomplete word/prefix[2],
making it seem as if the right thing is happening behind the scenes; but the
new 'completions' command would list all of them, which is undesirable.

(We could make the command do its own additional filtering step, but it's
better to produce the correct set of candidates in the first place.)

----

Finally, there's a lot of complexity (and consequently some bugs) caused by
not normalising the token sequence to ensure that the Thing To Be Completed
is *always* the final token.  At present, if the user effectively
tab-completes at an empty string, then we end up with a token sequence
ending with the *previous* (and already-complete) token.  Some of the
matchers are attempting to handle this by looking for tokens-of-interest in
both the current *and* the previous token; but it greatly simplifies the
logic if we instead ensure that the token sequence is more consistent, so
that if we're completing an empty string then the token sequence simply ends
with an empty string 'token'.

----

[1] I do have one question about `CONSTANT_SYNTAX` and `VAR_SYNTAX`:

https://www.php.net/manual/en/language.variables.basics.php gives a
near-identical pattern (and suggests that this applies to all PHP
identifiers, rather than just variables); but your pattern includes the
character 0x7f (DEL), whereas the one in the manual starts that range from
0x80.  I'm not sure whether this indicates a change/fix to the manual since
the code was written, or if you've intentionally added that DEL char to your
regexps (but I can't think why that would be).

```php
const CONSTANT_SYNTAX = '^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$';
const VAR_SYNTAX = '^\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$';
```

The manual says:

> Variable names follow the same rules as other labels in PHP. A valid
> variable name starts with a letter or underscore, followed by any number
> of letters, numbers, or underscores. As a regular expression, it would be
> expressed thus: `^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$`
>
> Note: For our purposes here, a letter is a-z, A-Z, and the bytes from 128
> through 255 (0x80-0xff).

So this may be a bug in the current regexps?

----

[2] What the incomplete word/prefix will actually be is another source of
confusion.  AFAICS, PHP's readline support provides no control over the set
of characters which act as word breaks for the purpose of completing the
current 'word'; and the defaults we're stuck with produce some fairly
inconsistent behaviours for completing PHP code.

The current code was handling things appropriately, but there was absolutely
no documentation of the reasons why certain things were the way they were.
I ended up spending a bunch of time trying to make things more consistent
for the new 'completions' command, only to find that those changes didn't
work in readline itself.

This was a documentation problem in large part (and the new documentation
will be beneficial to anyone looking to hack on this code in the future),
but we also need to define those word break characters in the code so that
the 'completions' command will supply the same arguments that Readline would
supply to the callback function.
