### PR TITLE
Load user-defined includes using `include_once`

### DIFF
--- a/src/Shell.php
+++ b/src/Shell.php
@@ -442,7 +442,7 @@ class Shell extends Application
             \set_error_handler([$__psysh__, 'handleError']);
             foreach ($__psysh__->getIncludes() as $__psysh_include__) {
                 try {
-                    include $__psysh_include__;
+                    include_once $__psysh_include__;
                 } catch (\Error $_e) {
                     $__psysh__->writeException(ErrorException::fromError($_e));
                 } catch (\Exception $_e) {


### PR DESCRIPTION
I have a legacy app that requires loading an init file, so in my config I have something like:
```php
<?php
return [
//...
    'defaultIncludes' => ['src/lib/common.php'],
];
```

When running `psysh`, everything works fine and I have access to all my stuff, but when adding `eval(\Psy\sh());` to my unit test, it breaks because the test will already include that `common.php`, and then PsySh will try to load it again. 
Using `include_once` solves this issue, and I can't think of a case where loading multiple times would be desirable (but if you can think of one, I can rework my change to make that conditional with another config option).


Running the tests:
```
psysh|master ⇒ make test
vendor/bin/phpunit 
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

.............................................................   61 / 2755 (  2%)
..................S.............................SSSS.........  122 / 2755 (  4%)
.............................................................  183 / 2755 (  6%)
.............................................................  244 / 2755 (  8%)
.............................................................  305 / 2755 ( 11%)
.....................................SSSSSS..................  366 / 2755 ( 13%)
.............................................................  427 / 2755 ( 15%)
.............................................................  488 / 2755 ( 17%)
.............................................................  549 / 2755 ( 19%)
.....................S.................S.....................  610 / 2755 ( 22%)
.........S...................................................  671 / 2755 ( 24%)
.............................................................  732 / 2755 ( 26%)
.............................................................  793 / 2755 ( 28%)
......SSSS...................................................  854 / 2755 ( 30%)
.............................................................  915 / 2755 ( 33%)
.......S.....................................................  976 / 2755 ( 35%)
............................................................. 1037 / 2755 ( 37%)
............................................................. 1098 / 2755 ( 39%)
............................................................. 1159 / 2755 ( 42%)
............................................................. 1220 / 2755 ( 44%)
............................................................. 1281 / 2755 ( 46%)
............................................................. 1342 / 2755 ( 48%)
............................................................. 1403 / 2755 ( 50%)
............................................................. 1464 / 2755 ( 53%)
............................................................. 1525 / 2755 ( 55%)
............................................................. 1586 / 2755 ( 57%)
............................................................. 1647 / 2755 ( 59%)
............................................................. 1708 / 2755 ( 61%)
............................................................. 1769 / 2755 ( 64%)
............................................................. 1830 / 2755 ( 66%)
............................................................. 1891 / 2755 ( 68%)
............................................................. 1952 / 2755 ( 70%)
............................................................. 2013 / 2755 ( 73%)
............................................................. 2074 / 2755 ( 75%)
............................................................. 2135 / 2755 ( 77%)
............................................................. 2196 / 2755 ( 79%)
............................................................. 2257 / 2755 ( 81%)
............................................................. 2318 / 2755 ( 84%)
............................................................. 2379 / 2755 ( 86%)
............................................................. 2440 / 2755 ( 88%)
............................................................. 2501 / 2755 ( 90%)
............................................................. 2562 / 2755 ( 92%)
............................................................. 2623 / 2755 ( 95%)
............................................................. 2684 / 2755 ( 97%)
............................................................. 2745 / 2755 ( 99%)
..........                                                    2755 / 2755 (100%)

Time: 1.69 seconds, Memory: 76.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 2755, Assertions: 3443, Skipped: 19.
```