### PR TITLE
Updated StyleCI config for symfony preset change

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,13 +4,11 @@ preset: symfony
 
 enabled:
   - align_double_arrow
-  - native_constant_invocation
   - native_function_invocation
   - ordered_use
   - strict
 
 disabled:
-  - native_constant_invocation_symfony
   - native_function_invocation_symfony
   - no_superfluous_phpdoc_tags_symfony
   - pow_to_exponentiation


### PR DESCRIPTION
The Symfony code style guide was changed yesterday to use the full-fat variant of the constant slash rule.  As such, once StyleCI deploys these changes later today, this PR will need merging.

---

NB This repo is included in the integration tests StyleCI has before preset changes are rolled out (indeed, before any changes at all to the entire "fixing platform" are deployed), to make sure it is never broken.