### PR TITLE
add support for runkit7 < 4.0.0a1

### DIFF
--- a/src/ExecutionLoop/RunkitReloader.php
+++ b/src/ExecutionLoop/RunkitReloader.php
@@ -30,7 +30,8 @@ class RunkitReloader extends AbstractListener
      */
     public static function isSupported()
     {
-        return \extension_loaded('runkit');
+        // runkit_import was removed in runkit7-4.0.0a1 
+        return \extension_loaded('runkit') || \extension_loaded('runkit7') && \function_exists('runkit_import');
     }
 
     /**
@@ -101,14 +102,22 @@ class RunkitReloader extends AbstractListener
         // }
 
         foreach ($modified as $file) {
-            runkit_import($file, (
+            $flags = (
                 RUNKIT_IMPORT_FUNCTIONS |
                 RUNKIT_IMPORT_CLASSES |
                 RUNKIT_IMPORT_CLASS_METHODS |
                 RUNKIT_IMPORT_CLASS_CONSTS |
                 RUNKIT_IMPORT_CLASS_PROPS |
                 RUNKIT_IMPORT_OVERRIDE
-            ));
+            );
+            
+            // these two const cannot be used with RUNKIT_IMPORT_OVERRIDE  in runkit7 
+            if (\extension_loaded('runkit7')) {
+                $flags &= ~RUNKIT_IMPORT_CLASS_PROPS & ~RUNKIT_IMPORT_CLASS_STATIC_PROPS;
+                runkit7_import($file, $flags);
+            } else {
+                runkit_import($file, $flags);
+            }
         }
     }
 


### PR DESCRIPTION
Enable partial php 7 support for [runkit7](https://www.php.net/manual/en/book.runkit7.php) before version 4.0.0a1 where `runkit_import` function was removed.