### PR TITLE
Fix non-nullable internal function deprecation notice

### DIFF
--- a/src/VarDumper/Dumper.php
+++ b/src/VarDumper/Dumper.php
@@ -74,7 +74,7 @@ class Dumper extends CliDumper
         $map = self::$controlCharsMap;
         $cchr = $this->styles['cchr'];
 
-        $chunks = \preg_split(self::$controlCharsRx, $value, null, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
+        $chunks = \preg_split(self::$controlCharsRx, $value, -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE);
         foreach ($chunks as $chunk) {
             if (\preg_match(self::$onlyControlCharsRx, $chunk)) {
                 $chars = '';


### PR DESCRIPTION
In PHP 8.1, [Passing `null` to a non-nullable parameter causes a deprecation notice](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation).

In Psysh, `Psy\VarDumper\Dumper::style()` method has a `preg_split` call that triggers this deprecation:

```
Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in src/VarDumper/Dumper.php on line 77
```

This PR fixes it by changing the `$limit` parameter value to the default `-1` from `null`.