### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "^8.0 || ^7.0 || ^5.5.9",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "symfony/console": "~5.0|~4.0|~3.0|^2.4.2|~2.3.10",
-        "symfony/var-dumper": "~5.0|~4.0|~3.0|~2.7",
+        "symfony/console": "~6.0|~5.0|~4.0|~3.0|^2.4.2|~2.3.10",
+        "symfony/var-dumper": "~6.0|~5.0|~4.0|~3.0|~2.7",
         "nikic/php-parser": "~4.0|~3.0|~2.0|~1.3"
     },
     "require-dev": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/172966/124846317-21999300-dfcb-11eb-8426-992ed189ae50.png)

Tested by adding `"minimum-stability": "dev"` but I'm not sure we should merge this to `main` branch, since Symfony 6 is not stable yet and any tagged version to 0.10.x (after the merge) will be installable when Symfony 6 arrived.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>