### PR TITLE
Style integer and float values separately

### DIFF
--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -195,6 +195,8 @@ class ShellOutput extends ConsoleOutput
 
         // Types
         $formatter->setStyle('number', new OutputFormatterStyle('magenta'));
+        $formatter->setStyle('integer', new OutputFormatterStyle('magenta'));
+        $formatter->setStyle('float', new OutputFormatterStyle('yellow'));
         $formatter->setStyle('string', new OutputFormatterStyle('green'));
         $formatter->setStyle('bool', new OutputFormatterStyle('cyan'));
         $formatter->setStyle('keyword', new OutputFormatterStyle('yellow'));

--- a/src/VarDumper/Presenter.php
+++ b/src/VarDumper/Presenter.php
@@ -33,6 +33,8 @@ class Presenter
     ];
     private $styles = [
         'num'       => 'number',
+        'integer'   => 'integer',
+        'float'     => 'float',
         'const'     => 'const',
         'str'       => 'string',
         'cchr'      => 'default',


### PR DESCRIPTION
Adresses #664 

For now this change does not have any effect. When `symfony/var-dumper` 5.4.0 is released and PsySH installations start picking it up, integer and float values will look like this:

![example](https://i.imgur.com/w8Ka4sv.png)

Issue on the VarDumper: https://github.com/symfony/symfony/issues/39393
PR to the VarDumper: https://github.com/symfony/symfony/pull/41962