### PR TITLE
[PHP 8.1] Fix deprecation notice when `readline_info` value is passed to `stripos()`

### DIFF
--- a/src/Readline/GNUReadline.php
+++ b/src/Readline/GNUReadline.php
@@ -49,7 +49,7 @@ class GNUReadline implements Readline
      */
     public static function supportsBracketedPaste()
     {
-        return self::isSupported() && \stripos(\readline_info('library_version'), 'editline') === false;
+        return self::isSupported() && \stripos((string) \readline_info('library_version'), 'editline') === false;
     }
 
     /**


### PR DESCRIPTION
[PHP 8.1 deprecates passing `null` to non-nullable internal function parameters](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation).

In `src/Readline/GNUReadline.php:52`, there is an `stripos` call that receives the return value from `readline_info` function. This function can return `null`, resulting in a deprecation notice in PHP 8.1.
This casts the return value to `(string)`.

![image](https://user-images.githubusercontent.com/811553/138898729-e4062c3c-c954-4450-bd26-55d20dc7eaca.png)
