### PR TITLE
Dropped super old deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build/psysh-php70: $(PSYSH_SRC) $(PSYSH_SRC_FILES)
 	mkdir $@
 	cp -R $(PSYSH_SRC) $@/
 	sed -i -e "/^ *const VERSION =/ s/'.*'/'$(VERSION)+php70'/" $@/src/Shell.php
-	composer config --working-dir $@ platform.php 7.0.0
+	composer config --working-dir $@ platform.php 7.0.8
 	composer update --working-dir $@ $(COMPOSER_UPDATE_OPTS)
 
 build/psysh-php70-compat: $(PSYSH_SRC) $(PSYSH_SRC_FILES)
@@ -92,7 +92,7 @@ build/psysh-php70-compat: $(PSYSH_SRC) $(PSYSH_SRC_FILES)
 	mkdir $@
 	cp -R $(PSYSH_SRC) $@/
 	sed -i -e "/^ *const VERSION =/ s/'.*'/'$(VERSION)+php70-compat'/" $@/src/Shell.php
-	composer config --working-dir $@ platform.php 7.0.0
+	composer config --working-dir $@ platform.php 7.0.8
 	composer require --working-dir $@ $(COMPOSER_REQUIRE_OPTS) symfony/polyfill-iconv symfony/polyfill-mbstring hoa/console:^2.15
 	composer update --working-dir $@ $(COMPOSER_UPDATE_OPTS)
 

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^7.0",
+        "php": "^8.0 || ^7.0.8",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "symfony/console": "~6.0|~5.0|~4.0|~3.4",
-        "symfony/var-dumper": "~6.0|~5.0|~4.0|~3.4",
-        "nikic/php-parser": "~4.0|~3.1"
+        "symfony/console": "^6.0 || ^5.0 || ^4.0 || ^3.4",
+        "symfony/var-dumper": "^6.0 || ^5.0 || ^4.0 || ^3.4",
+        "nikic/php-parser": "^4.0 || ^3.1"
     },
     "require-dev": {
         "hoa/console": "3.17.05.02",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "php": "^8.0 || ^7.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "symfony/console": "~6.0|~5.0|~4.0|~3.0",
-        "symfony/var-dumper": "~6.0|~5.0|~4.0|~3.0|~2.7",
-        "nikic/php-parser": "~4.0|~3.0|~2.0"
+        "symfony/console": "~6.0|~5.0|~4.0|~3.4",
+        "symfony/var-dumper": "~6.0|~5.0|~4.0|~3.4",
+        "nikic/php-parser": "~4.0|~3.1"
     },
     "require-dev": {
         "hoa/console": "3.17.05.02",


### PR DESCRIPTION
PHP-Parser 2.0.0 only supported PHP 7.0, and nothing greater, and support for symfony console 2 was already dropped, so ditching symfony var-dumper 2 seems fair, too. Moving the min PHP version to 7.0.8 also enables the PHP 7.0 compatable phar build to use the latest symfony 3.x components.