### PR TITLE
Set allow-plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,11 @@
         }
     },
     "bin": ["bin/psysh"],
+    "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-main": "0.10.x-dev"


### PR DESCRIPTION
This new configuration has been introduced with Composer 2.2: https://github.com/composer/composer/releases/tag/2.2.0-RC1