### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/test/CodeCleaner/RequirePassTest.php
+++ b/test/CodeCleaner/RequirePassTest.php
@@ -94,6 +94,6 @@ class RequirePassTest extends CodeCleanerTestCase
 
     public function testResolveWorks()
     {
-        $this->assertEquals(__FILE__, RequirePass::resolve(__FILE__, 3));
+        $this->assertSame(__FILE__, RequirePass::resolve(__FILE__, 3));
     }
 }

--- a/test/Command/ListCommand/ClassConstantEnumeratorTest.php
+++ b/test/Command/ListCommand/ClassConstantEnumeratorTest.php
@@ -23,7 +23,7 @@ class ClassConstantEnumeratorTest extends EnumeratorTestCase
         $enumerator = new ClassConstantEnumerator($this->getPresenter());
         $input = $this->getInput($inputStr);
 
-        $this->assertEquals($expectedItems, $enumerator->enumerate($input, $reflector, $target));
+        $this->assertSame($expectedItems, $enumerator->enumerate($input, $reflector, $target));
     }
 
     public function enumerateInput()
@@ -169,7 +169,7 @@ class ClassConstantEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--constants --no-inherit');
         $reflector = new \ReflectionClass(Fixtures\InterfaceEcho::class);
 
-        $this->assertEquals([
+        $this->assertSame([
             'Interface Constants' => [
                 'E' => [
                     'name'  => 'E',

--- a/test/Command/ListCommand/ClassEnumeratorTest.php
+++ b/test/Command/ListCommand/ClassEnumeratorTest.php
@@ -22,10 +22,10 @@ class ClassEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--classes');
         $target = new Fixtures\ClassAlfa();
 
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
     }
 
     public function testEnumerateClasses()
@@ -58,7 +58,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $fixtureClasses);
+        $this->assertSame($expected, $fixtureClasses);
     }
 
     public function testEnumerateInterfaces()
@@ -86,7 +86,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $fixtureClasses);
+        $this->assertSame($expected, $fixtureClasses);
     }
 
     public function testEnumerateTraits()
@@ -111,7 +111,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $fixtureClasses);
+        $this->assertSame($expected, $fixtureClasses);
     }
 
     public function testEnumerateNamespace()
@@ -143,7 +143,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
         ];
 
         $this->assertArrayHasKey('Classes', $res);
-        $this->assertEquals($expectedClasses, $res['Classes']);
+        $this->assertSame($expectedClasses, $res['Classes']);
 
         $prefix = \PHP_VERSION === '7.4.0' ? '<keyword>static</keyword> ' : '';
         $expectedInterfaces = [
@@ -160,7 +160,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
             ],
         ];
         $this->assertArrayHasKey('Interfaces', $res);
-        $this->assertEquals($expectedInterfaces, $res['Interfaces']);
+        $this->assertSame($expectedInterfaces, $res['Interfaces']);
 
         $expectedTraits = [
             Fixtures\TraitFoxtrot::class => [
@@ -175,7 +175,7 @@ class ClassEnumeratorTest extends EnumeratorTestCase
             ],
         ];
         $this->assertArrayHasKey('Traits', $res);
-        $this->assertEquals($expectedTraits, $res['Traits']);
+        $this->assertSame($expectedTraits, $res['Traits']);
     }
 
     public function testEnumerateParentNamespace()

--- a/test/Command/ListCommand/ConstantEnumeratorTest.php
+++ b/test/Command/ListCommand/ConstantEnumeratorTest.php
@@ -22,7 +22,7 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
     {
         $enumerator = new ConstantEnumerator($this->getPresenter());
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input, null, null));
+        $this->assertSame([], $enumerator->enumerate($input, null, null));
     }
 
     public function testEnumerateReturnsNothingForTarget()
@@ -31,10 +31,10 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--constants');
         $target = new Fixtures\ClassAlfa();
 
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
     }
 
     public function testEnumerateInternalConstants()
@@ -56,7 +56,7 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
 
         foreach ($expected as $name => $value) {
             $this->assertArrayHasKey($name, $constants);
-            $this->assertEquals(['name' => $name, 'style' => 'const', 'value' => $value], $constants[$name]);
+            $this->assertSame(['name' => $name, 'style' => 'const', 'value' => $value], $constants[$name]);
         }
     }
 
@@ -76,7 +76,7 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
 
         $name = 'Psy\\Test\\Command\\ListCommand\\SOME_CONSTANT';
         $this->assertArrayHasKey($name, $constants);
-        $this->assertEquals(['name' => $name, 'style' => 'const', 'value' => $this->presentNumber(42)], $constants[$name]);
+        $this->assertSame(['name' => $name, 'style' => 'const', 'value' => $this->presentNumber(42)], $constants[$name]);
     }
 
     /**
@@ -125,7 +125,7 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $res['Constants']);
+        $this->assertSame($expected, $res['Constants']);
     }
 
     public function testEnumerateInternalAndUserNamespaceConstants()
@@ -144,6 +144,6 @@ class ConstantEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $res['User Constants']);
+        $this->assertSame($expected, $res['User Constants']);
     }
 }

--- a/test/Command/ListCommand/FunctionEnumeratorTest.php
+++ b/test/Command/ListCommand/FunctionEnumeratorTest.php
@@ -23,7 +23,7 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
     {
         $enumerator = new FunctionEnumerator($this->getPresenter());
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input));
+        $this->assertSame([], $enumerator->enumerate($input));
     }
 
     public function testEnumerateReturnsNothingForTarget()
@@ -32,10 +32,10 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--functions');
         $target = new Fixtures\ClassAlfa();
 
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
     }
 
     public function testEnumerateInternalFunctions()
@@ -57,7 +57,7 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
         foreach ($expected as $name) {
             $this->assertArrayHasKey($name, $functions);
             $signature = SignatureFormatter::format(new \ReflectionFunction($name));
-            $this->assertEquals(['name' => $name, 'style' => 'function', 'value' => $signature], $functions[$name]);
+            $this->assertSame(['name' => $name, 'style' => 'function', 'value' => $signature], $functions[$name]);
         }
     }
 
@@ -80,7 +80,7 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
         foreach ($expected as $name) {
             $this->assertArrayHasKey($name, $functions);
             $signature = SignatureFormatter::format(new \ReflectionFunction($name));
-            $this->assertEquals(['name' => $name, 'style' => 'function', 'value' => $signature], $functions[$name]);
+            $this->assertSame(['name' => $name, 'style' => 'function', 'value' => $signature], $functions[$name]);
         }
     }
 
@@ -105,7 +105,7 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $res['Functions']);
+        $this->assertSame($expected, $res['Functions']);
     }
 
     public function testEnumerateUserAndInternalNamespaceFunctions()
@@ -130,6 +130,6 @@ class FunctionEnumeratorTest extends EnumeratorTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $res['User Functions']);
+        $this->assertSame($expected, $res['User Functions']);
     }
 }

--- a/test/Command/ListCommand/GlobalVariableEnumeratorTest.php
+++ b/test/Command/ListCommand/GlobalVariableEnumeratorTest.php
@@ -19,7 +19,7 @@ class GlobalVariableEnumeratorTest extends EnumeratorTestCase
     {
         $enumerator = new GlobalVariableEnumerator($this->getPresenter());
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input));
+        $this->assertSame([], $enumerator->enumerate($input));
     }
 
     public function testEnumerateReturnsNothingForTarget()
@@ -28,10 +28,10 @@ class GlobalVariableEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--globals');
         $target = new Fixtures\ClassAlfa();
 
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
     }
 
     public function testEnumerate()
@@ -62,18 +62,18 @@ class GlobalVariableEnumeratorTest extends EnumeratorTestCase
         $style = 'global';
         $value = $this->presentNumber(42);
         $this->assertArrayHasKey('$'.$one, $globals);
-        $this->assertEquals(\compact('name', 'style', 'value'), $globals[$name]);
+        $this->assertSame(\compact('name', 'style', 'value'), $globals[$name]);
 
         $name = '$'.$two;
         $style = 'global';
         $value = '"\<string>string\</string>"';
         $this->assertArrayHasKey('$'.$two, $globals);
-        $this->assertEquals(\compact('name', 'style', 'value'), $globals[$name]);
+        $this->assertSame(\compact('name', 'style', 'value'), $globals[$name]);
 
         $name = '$'.$three;
         $style = 'global';
         $value = '[]';
         $this->assertArrayHasKey('$'.$three, $globals);
-        $this->assertEquals(\compact('name', 'style', 'value'), $globals[$name]);
+        $this->assertSame(\compact('name', 'style', 'value'), $globals[$name]);
     }
 }

--- a/test/Command/ListCommand/MethodEnumeratorTest.php
+++ b/test/Command/ListCommand/MethodEnumeratorTest.php
@@ -19,7 +19,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
     {
         $enumerator = new MethodEnumerator($this->getPresenter());
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input));
+        $this->assertSame([], $enumerator->enumerate($input));
     }
 
     public function testEnumerateReturnsNothingWithoutTarget()
@@ -27,7 +27,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
         $enumerator = new MethodEnumerator($this->getPresenter());
         $input = $this->getInput('--methods');
 
-        $this->assertEquals([], $enumerator->enumerate($input, null, null));
+        $this->assertSame([], $enumerator->enumerate($input, null, null));
     }
 
     public function testEnumeratePublicMethods()
@@ -41,7 +41,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Class Methods', $res);
         $methods = $res['Class Methods'];
 
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => [
                 'name'  => 'foo',
                 'style' => 'public',
@@ -121,7 +121,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Class Methods', $res);
         $methods = $res['Class Methods'];
 
-        $this->assertEquals([
+        $this->assertSame([
             'qux' => [
                 'name'  => 'qux',
                 'style' => 'public',
@@ -140,7 +140,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Interface Methods', $res);
         $methods = $res['Interface Methods'];
 
-        $this->assertEquals([
+        $this->assertSame([
             'doEcho' => [
                 'name'  => 'doEcho',
                 'style' => 'public',
@@ -159,7 +159,7 @@ class MethodEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Trait Methods', $res);
         $methods = $res['Trait Methods'];
 
-        $this->assertEquals([
+        $this->assertSame([
             'doFoxtrot' => [
                 'name'  => 'doFoxtrot',
                 'style' => 'public',

--- a/test/Command/ListCommand/PropertyEnumeratorTest.php
+++ b/test/Command/ListCommand/PropertyEnumeratorTest.php
@@ -19,7 +19,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
     {
         $enumerator = new PropertyEnumerator($this->getPresenter());
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input));
+        $this->assertSame([], $enumerator->enumerate($input));
     }
 
     public function testEnumerateReturnsNothingWithoutTarget()
@@ -27,7 +27,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
         $enumerator = new PropertyEnumerator($this->getPresenter());
         $input = $this->getInput('--properties');
 
-        $this->assertEquals([], $enumerator->enumerate($input, null, null));
+        $this->assertSame([], $enumerator->enumerate($input, null, null));
     }
 
     public function testEnumeratePublicProperties()
@@ -41,7 +41,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Class Properties', $res);
         $properties = $res['Class Properties'];
 
-        $this->assertEquals([
+        $this->assertSame([
             '$foo' => [
                 'name'  => '$foo',
                 'style' => 'public',
@@ -121,7 +121,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Class Properties', $res);
         $properties = $res['Class Properties'];
 
-        $this->assertEquals([
+        $this->assertSame([
             '$qux' => [
                 'name'  => '$qux',
                 'style' => 'public',
@@ -136,7 +136,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--properties');
 
         $res = $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceEcho::class), null);
-        $this->assertEquals([], $res);
+        $this->assertSame([], $res);
     }
 
     public function testTraitProperties()
@@ -149,7 +149,7 @@ class PropertyEnumeratorTest extends EnumeratorTestCase
         $this->assertArrayHasKey('Trait Properties', $res);
         $properties = $res['Trait Properties'];
 
-        $this->assertEquals([
+        $this->assertSame([
             '$someFoxtrot' => [
                 'name'  => '$someFoxtrot',
                 'style' => 'public',

--- a/test/Command/ListCommand/VariableEnumeratorTest.php
+++ b/test/Command/ListCommand/VariableEnumeratorTest.php
@@ -27,7 +27,7 @@ class VariableEnumeratorTest extends EnumeratorTestCase
 
         $enumerator = new VariableEnumerator($this->getPresenter(), $context);
         $input = $this->getInput('');
-        $this->assertEquals([], $enumerator->enumerate($input));
+        $this->assertSame([], $enumerator->enumerate($input));
     }
 
     public function testEnumerateReturnsNothingForTarget()
@@ -43,10 +43,10 @@ class VariableEnumeratorTest extends EnumeratorTestCase
         $input = $this->getInput('--vars');
         $target = new Fixtures\ClassAlfa();
 
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
-        $this->assertEquals([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), null));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass($target), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\InterfaceDelta::class), $target));
+        $this->assertSame([], $enumerator->enumerate($input, new \ReflectionClass(Fixtures\TraitFoxtrot::class), $target));
     }
 
     public function testEnumerateEnumerates()

--- a/test/Command/ThrowUpCommandTest.php
+++ b/test/Command/ThrowUpCommandTest.php
@@ -35,7 +35,7 @@ class ThrowUpCommandTest extends \Psy\Test\TestCase
         $command->setApplication($shell);
         $tester = new CommandTester($command);
         $tester->execute($args);
-        $this->assertEquals('', $tester->getDisplay());
+        $this->assertSame('', $tester->getDisplay());
     }
 
     public function executeThis()

--- a/test/ConfigPathsTest.php
+++ b/test/ConfigPathsTest.php
@@ -23,17 +23,17 @@ class ConfigPathsTest extends TestCase
             'runtimeDir' => 'baz',
         ], new TestableEnv());
 
-        $this->assertEquals(['foo'], $paths->configDirs());
-        $this->assertEquals(['bar'], $paths->dataDirs());
-        $this->assertEquals('baz', $paths->runtimeDir());
+        $this->assertSame(['foo'], $paths->configDirs());
+        $this->assertSame(['bar'], $paths->dataDirs());
+        $this->assertSame('baz', $paths->runtimeDir());
 
         $paths->overrideDirs([
             'configDir' => 'qux',
         ]);
 
-        $this->assertEquals(['qux'], $paths->configDirs());
-        $this->assertEquals(['bar'], $paths->dataDirs());
-        $this->assertEquals('baz', $paths->runtimeDir());
+        $this->assertSame(['qux'], $paths->configDirs());
+        $this->assertSame(['bar'], $paths->dataDirs());
+        $this->assertSame('baz', $paths->runtimeDir());
 
         $paths->overrideDirs([
             'configDir'  => 'a',
@@ -41,9 +41,9 @@ class ConfigPathsTest extends TestCase
             'runtimeDir' => null,
         ]);
 
-        $this->assertEquals(['a'], $paths->configDirs());
-        $this->assertEquals(['b'], $paths->dataDirs());
-        $this->assertEquals(\sys_get_temp_dir().'/psysh', $paths->runtimeDir());
+        $this->assertSame(['a'], $paths->configDirs());
+        $this->assertSame(['b'], $paths->dataDirs());
+        $this->assertSame(\sys_get_temp_dir().'/psysh', $paths->runtimeDir());
     }
 
     /**
@@ -54,7 +54,7 @@ class ConfigPathsTest extends TestCase
         $paths = new ConfigPaths($overrides, new TestableEnv($env));
 
         $this->assertSame(\realpath($configDir), \realpath($paths->currentConfigDir()));
-        $this->assertSame(\array_map('realpath', $dataDirs), \array_values(\array_filter(\array_map('realpath', $paths->dataDirs()))));
+        $this->assertEquals(\array_map('realpath', $dataDirs), \array_values(\array_filter(\array_map('realpath', $paths->dataDirs()))));
         $this->assertSame(\realpath($runtimeDir), \realpath($paths->runtimeDir()));
     }
 

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -357,10 +357,10 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($formatter->hasStyle('luigi'));
 
         $mario = $formatter->getStyle('mario');
-        $this->assertEquals("\e[37;41mwheee\e[39;49m", $mario->apply('wheee'));
+        $this->assertSame("\e[37;41mwheee\e[39;49m", $mario->apply('wheee'));
 
         $luigi = $formatter->getStyle('luigi');
-        $this->assertEquals("\e[37;42mwheee\e[39;49m", $luigi->apply('wheee'));
+        $this->assertSame("\e[37;42mwheee\e[39;49m", $luigi->apply('wheee'));
     }
 
     public function testSetFormatterStylesRuntimeUpdates()
@@ -380,10 +380,10 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($formatter->hasStyle('luigi'));
 
         $mario = $formatter->getStyle('mario');
-        $this->assertEquals("\e[37;41mwheee\e[39;49m", $mario->apply('wheee'));
+        $this->assertSame("\e[37;41mwheee\e[39;49m", $mario->apply('wheee'));
 
         $luigi = $formatter->getStyle('luigi');
-        $this->assertEquals("\e[37;42mwheee\e[39;49m", $luigi->apply('wheee'));
+        $this->assertSame("\e[37;42mwheee\e[39;49m", $luigi->apply('wheee'));
 
         $config->setFormatterStyles([
             'mario' => ['red', 'white'],
@@ -391,10 +391,10 @@ class ConfigurationTest extends TestCase
         ]);
 
         $mario = $formatter->getStyle('mario');
-        $this->assertEquals("\e[31;47mwheee\e[39;49m", $mario->apply('wheee'));
+        $this->assertSame("\e[31;47mwheee\e[39;49m", $mario->apply('wheee'));
 
         $luigi = $formatter->getStyle('luigi');
-        $this->assertEquals("\e[32;47mwheee\e[39;49m", $luigi->apply('wheee'));
+        $this->assertSame("\e[32;47mwheee\e[39;49m", $luigi->apply('wheee'));
     }
 
     /**
@@ -437,19 +437,19 @@ class ConfigurationTest extends TestCase
     {
         $input = $this->getBoundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
-        $this->assertEquals($colorMode, $config->colorMode());
-        $this->assertEquals($interactiveMode, $config->interactiveMode());
-        $this->assertEquals($rawOutput, $config->rawOutput());
-        $this->assertEquals($yolo, $config->yolo());
+        $this->assertSame($verbosity, $config->verbosity());
+        $this->assertSame($colorMode, $config->colorMode());
+        $this->assertSame($interactiveMode, $config->interactiveMode());
+        $this->assertSame($rawOutput, $config->rawOutput());
+        $this->assertSame($yolo, $config->yolo());
 
         $input = $this->getUnboundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
-        $this->assertEquals($colorMode, $config->colorMode());
-        $this->assertEquals($interactiveMode, $config->interactiveMode());
-        $this->assertEquals($rawOutput, $config->rawOutput());
-        $this->assertEquals($yolo, $config->yolo());
+        $this->assertSame($verbosity, $config->verbosity());
+        $this->assertSame($colorMode, $config->colorMode());
+        $this->assertSame($interactiveMode, $config->interactiveMode());
+        $this->assertSame($rawOutput, $config->rawOutput());
+        $this->assertSame($yolo, $config->yolo());
     }
 
     public function inputStrings()
@@ -467,16 +467,16 @@ class ConfigurationTest extends TestCase
     {
         $input = $this->getBoundStringInput('--raw-output --color --interactive --verbose');
         $config = Configuration::fromInput($input);
-        $this->assertEquals(Configuration::VERBOSITY_VERBOSE, $config->verbosity());
-        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode());
-        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
+        $this->assertSame(Configuration::VERBOSITY_VERBOSE, $config->verbosity());
+        $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode());
+        $this->assertSame(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
         $this->assertFalse($config->rawOutput(), '--raw-output is ignored with interactive input');
 
         $input = $this->getBoundStringInput('--verbose --quiet --color --no-color --interactive --no-interactive');
         $config = Configuration::fromInput($input);
-        $this->assertEquals(Configuration::VERBOSITY_QUIET, $config->verbosity(), '--quiet trumps --verbose');
-        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode(), '--color trumps --no-color');
-        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode(), '--interactive trumps --no-interactive');
+        $this->assertSame(Configuration::VERBOSITY_QUIET, $config->verbosity(), '--quiet trumps --verbose');
+        $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode(), '--color trumps --no-color');
+        $this->assertSame(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode(), '--interactive trumps --no-interactive');
     }
 
     /**
@@ -486,11 +486,11 @@ class ConfigurationTest extends TestCase
     {
         $input = $this->getBoundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertSame($verbosity, $config->verbosity());
 
         $input = $this->getUnboundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
+        $this->assertSame($verbosity, $config->verbosity());
     }
 
     public function verbosityInputStrings()
@@ -520,9 +520,9 @@ class ConfigurationTest extends TestCase
     {
         $input = $this->getBoundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
-        $this->assertEquals($interactiveMode, $config->interactiveMode());
-        $this->assertEquals($rawOutput, $config->rawOutput());
+        $this->assertSame($verbosity, $config->verbosity());
+        $this->assertSame($interactiveMode, $config->interactiveMode());
+        $this->assertSame($rawOutput, $config->rawOutput());
 
         if ($skipUnbound) {
             $this->markTestSkipped($inputString.' fails with unbound input');
@@ -530,9 +530,9 @@ class ConfigurationTest extends TestCase
 
         $input = $this->getUnboundStringInput($inputString);
         $config = Configuration::fromInput($input);
-        $this->assertEquals($verbosity, $config->verbosity());
-        $this->assertEquals($interactiveMode, $config->interactiveMode());
-        $this->assertEquals($rawOutput, $config->rawOutput());
+        $this->assertSame($verbosity, $config->verbosity());
+        $this->assertSame($interactiveMode, $config->interactiveMode());
+        $this->assertSame($rawOutput, $config->rawOutput());
     }
 
     public function shortInputStrings()
@@ -551,13 +551,13 @@ class ConfigurationTest extends TestCase
     {
         $input = $this->getBoundStringInput('--ansi --interaction');
         $config = Configuration::fromInput($input);
-        $this->assertEquals(Configuration::COLOR_MODE_FORCED, $config->colorMode());
-        $this->assertEquals(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
+        $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode());
+        $this->assertSame(Configuration::INTERACTIVE_MODE_FORCED, $config->interactiveMode());
 
         $input = $this->getBoundStringInput('--no-ansi --no-interaction');
         $config = Configuration::fromInput($input);
-        $this->assertEquals(Configuration::COLOR_MODE_DISABLED, $config->colorMode());
-        $this->assertEquals(Configuration::INTERACTIVE_MODE_DISABLED, $config->interactiveMode());
+        $this->assertSame(Configuration::COLOR_MODE_DISABLED, $config->colorMode());
+        $this->assertSame(Configuration::INTERACTIVE_MODE_DISABLED, $config->interactiveMode());
     }
 
     private function getBoundStringInput($string, $configFile = null)

--- a/test/ContextTest.php
+++ b/test/ContextTest.php
@@ -33,7 +33,7 @@ class ContextTest extends TestCase
         $this->assertNull($context->get('_'));
         $this->assertNull($context->getReturnValue());
 
-        $this->assertEquals(['_' => null], $context->getAll());
+        $this->assertSame(['_' => null], $context->getAll());
 
         $e = new \Exception('eeeeeee');
         $obj = new \stdClass();
@@ -65,7 +65,7 @@ class ContextTest extends TestCase
             '__dir'       => 'dir',
         ];
 
-        $this->assertEquals($expected, $context->getAll());
+        $this->assertSame($expected, $context->getAll());
     }
 
     public function testSetAll()
@@ -95,11 +95,11 @@ class ContextTest extends TestCase
 
         $context->setAll($vars);
 
-        $this->assertEquals('Foo', $context->get('foo'));
-        $this->assertEquals(123, $context->get('bar'));
+        $this->assertSame('Foo', $context->get('foo'));
+        $this->assertSame(123, $context->get('bar'));
         $this->assertSame($baz, $context->get('baz'));
 
-        $this->assertEquals(['foo' => 'Foo', 'bar' => 123, 'baz' => $baz, '_' => null], $context->getAll());
+        $this->assertSame(['foo' => 'Foo', 'bar' => 123, 'baz' => $baz, '_' => null], $context->getAll());
     }
 
     /**
@@ -141,8 +141,8 @@ class ContextTest extends TestCase
 
         $val = 'some string';
         $context->setReturnValue($val);
-        $this->assertEquals($val, $context->getReturnValue());
-        $this->assertEquals($val, $context->get('_'));
+        $this->assertSame($val, $context->getReturnValue());
+        $this->assertSame($val, $context->get('_'));
 
         $obj = new \stdClass();
         $context->setReturnValue($obj);
@@ -177,8 +177,8 @@ class ContextTest extends TestCase
     {
         $context = new Context();
         $context->setLastStdout('ouuuuut');
-        $this->assertEquals('ouuuuut', $context->getLastStdout());
-        $this->assertEquals('ouuuuut', $context->get('__out'));
+        $this->assertSame('ouuuuut', $context->getLastStdout());
+        $this->assertSame('ouuuuut', $context->get('__out'));
     }
 
     public function testLastStdoutThrowsSometimes()
@@ -226,14 +226,14 @@ class ContextTest extends TestCase
         $this->assertNull($context->getBoundClass());
 
         $context->setBoundClass(Shell::class);
-        $this->assertEquals(Shell::class, $context->getBoundClass());
+        $this->assertSame(Shell::class, $context->getBoundClass());
 
         $context->setBoundObject(new \stdClass());
         $this->assertNotNull($context->getBoundObject());
         $this->assertNull($context->getBoundClass());
 
         $context->setBoundClass(Shell::class);
-        $this->assertEquals(Shell::class, $context->getBoundClass());
+        $this->assertSame(Shell::class, $context->getBoundClass());
         $this->assertNull($context->getBoundObject());
 
         $context->setBoundClass(null);
@@ -256,15 +256,15 @@ class ContextTest extends TestCase
         $context = new Context();
         $context->setCommandScopeVariables($vars);
 
-        $this->assertEquals($vars, $context->getCommandScopeVariables());
+        $this->assertSame($vars, $context->getCommandScopeVariables());
 
-        $this->assertEquals($__function, $context->get('__function'));
-        $this->assertEquals($__method, $context->get('__method'));
-        $this->assertEquals($__class, $context->get('__class'));
-        $this->assertEquals($__namespace, $context->get('__namespace'));
-        $this->assertEquals($__file, $context->get('__file'));
-        $this->assertEquals($__line, $context->get('__line'));
-        $this->assertEquals($__dir, $context->get('__dir'));
+        $this->assertSame($__function, $context->get('__function'));
+        $this->assertSame($__method, $context->get('__method'));
+        $this->assertSame($__class, $context->get('__class'));
+        $this->assertSame($__namespace, $context->get('__namespace'));
+        $this->assertSame($__file, $context->get('__file'));
+        $this->assertSame($__line, $context->get('__line'));
+        $this->assertSame($__dir, $context->get('__dir'));
 
         $someVars = \compact('__function', '__namespace', '__file', '__line', '__dir');
         $context->setCommandScopeVariables($someVars);
@@ -274,7 +274,7 @@ class ContextTest extends TestCase
     {
         $context = new Context();
 
-        $this->assertEquals(
+        $this->assertSame(
             ['__function', '__method', '__class', '__namespace', '__file', '__line', '__dir'],
             $context->getUnusedCommandScopeVariableNames()
         );
@@ -287,7 +287,7 @@ class ContextTest extends TestCase
             '__dir'       => 'qux',
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             ['__method', '__class'],
             \array_values($context->getUnusedCommandScopeVariableNames())
         );

--- a/test/Exception/ErrorExceptionTest.php
+++ b/test/Exception/ErrorExceptionTest.php
@@ -115,8 +115,8 @@ class ErrorExceptionTest extends \Psy\Test\TestCase
         $exception = ErrorException::fromError($error);
 
         $this->assertStringContainsString('PHP Error:  {{message}}', $exception->getMessage());
-        $this->assertEquals(0, $exception->getCode());
-        $this->assertEquals($error->getFile(), $exception->getFile());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($error->getFile(), $exception->getFile());
         $this->assertSame($exception->getPrevious(), $error);
     }
 }

--- a/test/Exception/FatalErrorExceptionTest.php
+++ b/test/Exception/FatalErrorExceptionTest.php
@@ -53,7 +53,7 @@ class FatalErrorExceptionTest extends \Psy\Test\TestCase
         $this->assertNotEquals(-1, $e->getLine());
 
         if (\version_compare(\PHP_VERSION, '8.0', '<')) {
-            $this->assertEquals(0, $e->getLine());
+            $this->assertSame(0, $e->getLine());
         }
     }
 }

--- a/test/Exception/ThrowUpExceptionTest.php
+++ b/test/Exception/ThrowUpExceptionTest.php
@@ -25,9 +25,9 @@ class ThrowUpExceptionTest extends \Psy\Test\TestCase
         $this->assertInstanceOf(Exception::class, $e);
         $this->assertInstanceOf(ThrowUpException::class, $e);
 
-        $this->assertEquals("Throwing Exception with message '{{message}}'", $e->getMessage());
-        $this->assertEquals('{{message}}', $e->getRawMessage());
-        $this->assertEquals(123, $e->getCode());
+        $this->assertSame("Throwing Exception with message '{{message}}'", $e->getMessage());
+        $this->assertSame('{{message}}', $e->getRawMessage());
+        $this->assertSame(123, $e->getCode());
         $this->assertSame($previous, $e->getPrevious());
     }
 

--- a/test/Exception/TypeErrorExceptionTest.php
+++ b/test/Exception/TypeErrorExceptionTest.php
@@ -23,17 +23,17 @@ class TypeErrorExceptionTest extends \Psy\Test\TestCase
         $this->assertInstanceOf(Exception::class, $e);
         $this->assertInstanceOf(TypeErrorException::class, $e);
 
-        $this->assertEquals('TypeError: {{message}}', $e->getMessage());
-        $this->assertEquals('{{message}}', $e->getRawMessage());
-        $this->assertEquals(13, $e->getCode());
+        $this->assertSame('TypeError: {{message}}', $e->getMessage());
+        $this->assertSame('{{message}}', $e->getRawMessage());
+        $this->assertSame(13, $e->getCode());
     }
 
     public function testStripsEvalFromMessage()
     {
         $message = 'Something or other, called in line 10: eval()\'d code';
         $e = new TypeErrorException($message);
-        $this->assertEquals($message, $e->getRawMessage());
-        $this->assertEquals('TypeError: Something or other', $e->getMessage());
+        $this->assertSame($message, $e->getRawMessage());
+        $this->assertSame('TypeError: Something or other', $e->getMessage());
     }
 
     public function testFromTypeError()
@@ -42,8 +42,8 @@ class TypeErrorExceptionTest extends \Psy\Test\TestCase
         $e = TypeErrorException::fromTypeError($previous);
 
         $this->assertInstanceOf(TypeErrorException::class, $e);
-        $this->assertEquals('TypeError: {{message}}', $e->getMessage());
-        $this->assertEquals('{{message}}', $e->getRawMessage());
-        $this->assertEquals(13, $e->getCode());
+        $this->assertSame('TypeError: {{message}}', $e->getMessage());
+        $this->assertSame('{{message}}', $e->getRawMessage());
+        $this->assertSame(13, $e->getCode());
     }
 }

--- a/test/Formatter/CodeFormatterTest.php
+++ b/test/Formatter/CodeFormatterTest.php
@@ -25,7 +25,7 @@ class CodeFormatterTest extends \Psy\Test\TestCase
         $formatted = CodeFormatter::format($reflector, Configuration::COLOR_MODE_FORCED);
         $formattedWithoutColors = self::stripTags($formatted);
 
-        $this->assertEquals($expected, self::trimLines($formattedWithoutColors));
+        $this->assertSame($expected, self::trimLines($formattedWithoutColors));
         $this->assertNotEquals($expected, self::trimLines($formatted));
     }
 
@@ -132,7 +132,7 @@ EOS;
         $formatted = CodeFormatter::formatCode($code, $startLine, $endLine, $markLine);
         $formattedWithoutColors = self::stripTags($formatted);
 
-        $this->assertEquals($expected, self::trimLines($formattedWithoutColors));
+        $this->assertSame($expected, self::trimLines($formattedWithoutColors));
         $this->assertNotEquals($expected, self::trimLines($formatted));
     }
 
@@ -235,7 +235,7 @@ EOS;
     public function testFormatSmallCodeLines($code, $startLine, $endLine, $markLine, $expected)
     {
         $formatted = CodeFormatter::formatCode($code, $startLine, $endLine, $markLine);
-        $this->assertEquals($expected, self::trimLines($formatted));
+        $this->assertSame($expected, self::trimLines($formatted));
     }
 
     public function smallCodeLines()

--- a/test/Input/FilterOptionsTest.php
+++ b/test/Input/FilterOptionsTest.php
@@ -32,7 +32,7 @@ class FilterOptionsTest extends \Psy\Test\TestCase
         $filterOptions = new FilterOptions();
         $filterOptions->bind($input);
 
-        $this->assertEquals($hasFilter, $filterOptions->hasFilter());
+        $this->assertSame($hasFilter, $filterOptions->hasFilter());
     }
 
     public function validInputs()
@@ -81,7 +81,7 @@ class FilterOptionsTest extends \Psy\Test\TestCase
         $filterOptions = new FilterOptions();
         $filterOptions->bind($input);
 
-        $this->assertEquals($matches, $filterOptions->match($str));
+        $this->assertSame($matches, $filterOptions->match($str));
     }
 
     public function matchData()

--- a/test/ParserFactoryTest.php
+++ b/test/ParserFactoryTest.php
@@ -35,7 +35,7 @@ class ParserFactoryTest extends \PhpUnit\Framework\TestCase
             return;
         }
 
-        $this->assertEquals(ParserFactory::ONLY_PHP7, $factory->getDefaultKind());
+        $this->assertSame(ParserFactory::ONLY_PHP7, $factory->getDefaultKind());
     }
 
     public function testCreateParser()

--- a/test/Readline/GNUReadlineTest.php
+++ b/test/Readline/GNUReadlineTest.php
@@ -33,7 +33,7 @@ class GNUReadlineTest extends \Psy\Test\TestCase
     public function testReadlineName()
     {
         $readline = new GNUReadline($this->historyFile);
-        $this->assertEquals(\readline_info('readline_name'), 'psysh');
+        $this->assertSame(\readline_info('readline_name'), 'psysh');
     }
 
     public function testHistory()

--- a/test/Readline/LibeditTest.php
+++ b/test/Readline/LibeditTest.php
@@ -47,7 +47,7 @@ class LibeditTest extends \Psy\Test\TestCase
     public function testReadlineName()
     {
         $readline = new Libedit($this->historyFile);
-        $this->assertEquals(\readline_info('readline_name'), 'psysh');
+        $this->assertSame(\readline_info('readline_name'), 'psysh');
     }
 
     public function testHistory()

--- a/test/Reflection/ReflectionClassConstantTest.php
+++ b/test/Reflection/ReflectionClassConstantTest.php
@@ -42,7 +42,7 @@ class ReflectionClassConstantTest extends \Psy\Test\TestCase
     public function testExport()
     {
         $ret = ReflectionClassConstant::export($this, 'CONSTANT_ONE', true);
-        $this->assertEquals($ret, 'Constant [ public string CONSTANT_ONE ] { one }');
+        $this->assertSame($ret, 'Constant [ public string CONSTANT_ONE ] { one }');
     }
 
     public function testExportOutput()
@@ -55,7 +55,7 @@ class ReflectionClassConstantTest extends \Psy\Test\TestCase
     {
         $refl = new ReflectionClassConstant($this, 'CONSTANT_ONE');
 
-        $this->assertEquals(\ReflectionMethod::IS_PUBLIC, $refl->getModifiers());
+        $this->assertSame(\ReflectionMethod::IS_PUBLIC, $refl->getModifiers());
         $this->assertFalse($refl->isPrivate());
         $this->assertFalse($refl->isProtected());
         $this->assertTrue($refl->isPublic());

--- a/test/Reflection/ReflectionConstantTest.php
+++ b/test/Reflection/ReflectionConstantTest.php
@@ -22,11 +22,11 @@ class ReflectionConstantTest extends \Psy\Test\TestCase
         $refl = new ReflectionConstant_('Psy\\Test\\Reflection\\SOME_CONSTANT');
 
         $this->assertFalse($refl->getDocComment());
-        $this->assertEquals('Psy\\Test\\Reflection\\SOME_CONSTANT', $refl->getName());
-        $this->assertEquals('Psy\\Test\\Reflection', $refl->getNamespaceName());
-        $this->assertEquals('yep', $refl->getValue());
+        $this->assertSame('Psy\\Test\\Reflection\\SOME_CONSTANT', $refl->getName());
+        $this->assertSame('Psy\\Test\\Reflection', $refl->getNamespaceName());
+        $this->assertSame('yep', $refl->getValue());
         $this->assertTrue($refl->inNamespace());
-        $this->assertEquals('Psy\\Test\\Reflection\\SOME_CONSTANT', (string) $refl);
+        $this->assertSame('Psy\\Test\\Reflection\\SOME_CONSTANT', (string) $refl);
         $this->assertNull($refl->getFileName());
     }
 
@@ -34,9 +34,9 @@ class ReflectionConstantTest extends \Psy\Test\TestCase
     {
         $refl = new ReflectionConstant_('PHP_VERSION');
 
-        $this->assertEquals('PHP_VERSION', $refl->getName());
-        $this->assertEquals('PHP_VERSION', (string) $refl);
-        $this->assertEquals(\PHP_VERSION, $refl->getValue());
+        $this->assertSame('PHP_VERSION', $refl->getName());
+        $this->assertSame('PHP_VERSION', (string) $refl);
+        $this->assertSame(\PHP_VERSION, $refl->getValue());
         $this->assertFalse($refl->inNamespace());
         $this->assertSame('', $refl->getNamespaceName());
     }
@@ -46,7 +46,7 @@ class ReflectionConstantTest extends \Psy\Test\TestCase
      */
     public function testIsMagicConstant($name, $is)
     {
-        $this->assertEquals($is, ReflectionConstant_::isMagicConstant($name));
+        $this->assertSame($is, ReflectionConstant_::isMagicConstant($name));
     }
 
     public function magicConstants()
@@ -79,7 +79,7 @@ class ReflectionConstantTest extends \Psy\Test\TestCase
     public function testExport()
     {
         $ret = ReflectionConstant_::export('Psy\\Test\\Reflection\\SOME_CONSTANT', true);
-        $this->assertEquals($ret, 'Constant [ string Psy\\Test\\Reflection\\SOME_CONSTANT ] { yep }');
+        $this->assertSame($ret, 'Constant [ string Psy\\Test\\Reflection\\SOME_CONSTANT ] { yep }');
     }
 
     public function testExportOutput()

--- a/test/Reflection/ReflectionLanguageConstructParameterTest.php
+++ b/test/Reflection/ReflectionLanguageConstructParameterTest.php
@@ -28,7 +28,7 @@ class ReflectionLanguageConstructParameterTest extends \Psy\Test\TestCase
         ]);
 
         $this->assertNull($refl->getClass());
-        $this->assertEquals('one', $refl->getName());
+        $this->assertSame('one', $refl->getName());
         $this->assertFalse($refl->isArray());
         $this->assertTrue($refl->isDefaultValueAvailable());
         $this->assertNull($refl->getDefaultValue());
@@ -42,7 +42,7 @@ class ReflectionLanguageConstructParameterTest extends \Psy\Test\TestCase
         ]);
 
         $this->assertNull($refl->getClass());
-        $this->assertEquals('two', $reflTwo->getName());
+        $this->assertSame('two', $reflTwo->getName());
         $this->assertTrue($reflTwo->isArray());
         $this->assertFalse($reflTwo->isDefaultValueAvailable());
         $this->assertNull($reflTwo->getDefaultValue());
@@ -54,10 +54,10 @@ class ReflectionLanguageConstructParameterTest extends \Psy\Test\TestCase
         ]);
 
         $this->assertNull($refl->getClass());
-        $this->assertEquals('three', $refl->getName());
+        $this->assertSame('three', $refl->getName());
         $this->assertFalse($refl->isArray());
         $this->assertTrue($refl->isDefaultValueAvailable());
-        $this->assertEquals(3, $refl->getDefaultValue());
+        $this->assertSame(3, $refl->getDefaultValue());
         $this->assertFalse($refl->isOptional());
         $this->assertFalse($refl->isPassedByReference());
     }

--- a/test/Reflection/ReflectionLanguageConstructTest.php
+++ b/test/Reflection/ReflectionLanguageConstructTest.php
@@ -21,8 +21,8 @@ class ReflectionLanguageConstructTest extends \Psy\Test\TestCase
     public function testConstruction($keyword)
     {
         $refl = new ReflectionLanguageConstruct($keyword);
-        $this->assertEquals($keyword, $refl->getName());
-        $this->assertEquals($keyword, (string) $refl);
+        $this->assertSame($keyword, $refl->getName());
+        $this->assertSame($keyword, (string) $refl);
     }
 
     /**

--- a/test/Reflection/ReflectionNamespaceTest.php
+++ b/test/Reflection/ReflectionNamespaceTest.php
@@ -19,8 +19,8 @@ class ReflectionNamespaceTest extends \Psy\Test\TestCase
     {
         $refl = new ReflectionNamespace('Psy\\Test\\Reflection');
 
-        $this->assertEquals('Psy\\Test\\Reflection', $refl->getName());
-        $this->assertEquals('Psy\\Test\\Reflection', (string) $refl);
+        $this->assertSame('Psy\\Test\\Reflection', $refl->getName());
+        $this->assertSame('Psy\\Test\\Reflection', (string) $refl);
     }
 
     public function testNotYetImplemented()

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -105,14 +105,14 @@ class ShellTest extends TestCase
 
     protected function assertArrayEquals(array $expected, array $actual, $message = '')
     {
-        if (\method_exists($this, 'assertEqualsCanonicalizing')) {
-            return $this->assertEqualsCanonicalizing($expected, $actual, $message);
+        if (\method_exists($this, 'assertSameCanonicalizing')) {
+            return $this->assertSameCanonicalizing($expected, $actual, $message);
         }
 
         \sort($expected);
         \sort($actual);
 
-        return $this->assertEquals($expected, $actual, $message);
+        return $this->assertSame($expected, $actual, $message);
     }
 
     public function testNonInteractiveDoesNotUpdateContext()
@@ -445,7 +445,7 @@ class ShellTest extends TestCase
 
         $shell->writeReturnValue($input);
         \rewind($stream);
-        $this->assertEquals($expected, \stream_get_contents($stream));
+        $this->assertSame($expected, \stream_get_contents($stream));
     }
 
     /**
@@ -461,7 +461,7 @@ class ShellTest extends TestCase
 
         $shell->writeReturnValue($input);
         \rewind($stream);
-        $this->assertEquals('', \stream_get_contents($stream));
+        $this->assertSame('', \stream_get_contents($stream));
     }
 
     public function getReturnValues()
@@ -537,7 +537,7 @@ class ShellTest extends TestCase
         $stream = $output->getStream();
         $shell = new Shell($this->getConfig());
         $shell->setOutput($output);
-        $this->assertEquals($expected, $shell->execute($input));
+        $this->assertSame($expected, $shell->execute($input));
         \rewind($stream);
         $this->assertSame('', \stream_get_contents($stream));
     }
@@ -547,7 +547,7 @@ class ShellTest extends TestCase
         return [
             ['return 12', 12],
             ['"{{return value}}"', '{{return value}}'],
-            ['1', '1'],
+            ['1', 1],
         ];
     }
 
@@ -563,7 +563,7 @@ class ShellTest extends TestCase
         $method = $refl->getMethod('hasCommand');
         $method->setAccessible(true);
 
-        $this->assertEquals($method->invokeArgs($shell, [$command]), $has);
+        $this->assertSame($method->invokeArgs($shell, [$command]), $has);
     }
 
     public function commandsToHas()

--- a/test/VersionUpdater/NoopCheckerTest.php
+++ b/test/VersionUpdater/NoopCheckerTest.php
@@ -20,6 +20,6 @@ class NoopCheckerTest extends \Psy\Test\TestCase
     {
         $checker = new NoopChecker();
         $this->assertTrue($checker->isLatest());
-        $this->assertEquals(Shell::VERSION, $checker->getLatest());
+        $this->assertSame(Shell::VERSION, $checker->getLatest());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assertion equals strict.