### PR TITLE
fix nullable params for getHistorySlice and allow for custom historyFile

### DIFF
--- a/src/Command/HistoryCommand.php
+++ b/src/Command/HistoryCommand.php
@@ -182,7 +182,7 @@ HELP
      *
      * @return array A slice of history
      */
-    private function getHistorySlice(?string $show, ?string $head, ?string $tail): array
+    private function getHistorySlice($show, $head, $tail): array
     {
         $history = $this->readline->listHistory();
 

--- a/src/Command/HistoryCommand.php
+++ b/src/Command/HistoryCommand.php
@@ -176,13 +176,13 @@ HELP
     /**
      * Retrieve a slice of the readline history.
      *
-     * @param string $show
-     * @param string $head
-     * @param string $tail
+     * @param string|null $show
+     * @param string|null $head
+     * @param string|null $tail
      *
-     * @return array A slilce of history
+     * @return array A slice of history
      */
-    private function getHistorySlice(string $show, string $head, string $tail): array
+    private function getHistorySlice(?string $show, ?string $head, ?string $tail): array
     {
         $history = $this->readline->listHistory();
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -56,6 +56,7 @@ class Configuration
         'errorLoggingLevel',
         'forceArrayIndexes',
         'formatterStyles',
+        'historyFile',
         'historySize',
         'interactiveMode',
         'manualDbFile',


### PR DESCRIPTION
getHistorySlice was broken due to the added typehints (only one of the 3 params will be a string). I've also added `historyFile` to the available options in the configuration to allow for supplying a custom HistoryFile location in the config file.