### PR TITLE
fix tab completion bug #698

### DIFF
--- a/src/TabCompletion/AutoCompleter.php
+++ b/src/TabCompletion/AutoCompleter.php
@@ -68,6 +68,8 @@ class AutoCompleter
         $tokens = \array_filter($tokens, function ($token) {
             return !AbstractMatcher::tokenIs($token, AbstractMatcher::T_WHITESPACE);
         });
+        // reset index from 0 to remove missing index number
+        $tokens = \array_values($tokens);
 
         $matches = [];
         foreach ($this->matchers as $matcher) {


### PR DESCRIPTION
## bug fix #698
PHP: 8.0.14
Psysh: 0.11.1

When input strings start with white spaces, $tokens has missing index number. 
eg:
* input : " Datetime::" + tab completion
* $tokens : index number 1 is missing.

So, add process to reset index numbers.

## Result
```
$ php bin/psysh 

Psy Shell v0.11.1 (PHP 8.0.14 — cli) by Justin Hileman
>>>  Datetime::
Datetime::ATOM                 Datetime::RFC1036              Datetime::RFC3339              Datetime::RFC822               Datetime::W3C                  Datetime::createFromImmutable  
Datetime::COOKIE               Datetime::RFC1123              Datetime::RFC3339_EXTENDED     Datetime::RFC850               Datetime::__set_state          Datetime::createFromInterface  
Datetime::ISO8601              Datetime::RFC2822              Datetime::RFC7231              Datetime::RSS                  Datetime::createFromFormat     Datetime::getLastErrors   
```

## var_dump($tokens)
### before bug fix
![issue-698_tokens_before](https://user-images.githubusercontent.com/6963921/149606874-20ecc3bc-727f-4665-bc7d-b65231e88886.png)

### after bug fix
![issue-698_tokens_after](https://user-images.githubusercontent.com/6963921/149606899-523cf1aa-46cf-482b-a5f7-497fe424813f.png)






