### PR TITLE
Fix PHP 8.x deprecated notice

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1373,7 +1373,7 @@ class Configuration
     {
         if (!isset($this->manualDb)) {
             $dbFile = $this->getManualDbFile();
-            if (\is_file($dbFile)) {
+            if (((string) $dbFile) !== '' && \is_file($dbFile)) {
                 try {
                     $this->manualDb = new \PDO('sqlite:'.$dbFile);
                 } catch (\PDOException $e) {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1373,7 +1373,7 @@ class Configuration
     {
         if (!isset($this->manualDb)) {
             $dbFile = $this->getManualDbFile();
-            if (((string) $dbFile) !== '' && \is_file($dbFile)) {
+            if ($dbFile !== null && \is_file($dbFile)) {
                 try {
                     $this->manualDb = new \PDO('sqlite:'.$dbFile);
                 } catch (\PDOException $e) {


### PR DESCRIPTION
If I try to run `psy\info()` command, PHP 8.x will report a deprecated notice:

```
PHP Deprecated: is_file(): Passing null to parameter #1 ($filename) of type string is deprecated in /home/user/tmp/psysh/src/Configuration.php on line 1376
```

In this commit, I've fixed this issue.
NOTE: Tests were failing previously.

(To the reviewers, I'm new to open-source contribution, so if you notice something wrong, please feel free to notify me.)