### PR TITLE
Suppress WARNING for TERM=dumb

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1209,6 +1209,10 @@ class Configuration
     public function getPager()
     {
         if (!isset($this->pager) && $this->usePcntl()) {
+            if (\getenv('TERM') === 'dumb') {
+                return false;
+            }
+
             if ($pager = \ini_get('cli.pager')) {
                 // use the default pager
                 $this->pager = $pager;

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -24,6 +24,7 @@ class ShellOutput extends ConsoleOutput
     const NUMBER_LINES = 128;
 
     private $paging = 0;
+    /** @var OutputPager */
     private $pager;
 
     /**


### PR DESCRIPTION
The `less` command outputs a WARNING message in the environment of `TERM=dumb`, so suppress this.

<img width="434" alt="スクリーンショット 2022-05-10 4 00 15" src="https://user-images.githubusercontent.com/822086/167482792-9d9045df-a87c-4093-bb45-064da651d8ca.png">

I'm going to fix some issues in the dumb environment. refs https://github.com/emacs-php/psysh.el/issues/8