### PR TITLE
[PHP 8.2] Fix deprecated `${var}` string interpolation syntax

### DIFF
--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -147,7 +147,7 @@ abstract class Command extends BaseCommand
 
                 $description = \str_replace("\n", "\n".\str_pad('', $max + 2, ' '), $argument->getDescription());
 
-                $messages[] = \sprintf(" <info>%-${max}s</info> %s%s", $argument->getName(), $description, $default);
+                $messages[] = \sprintf(" <info>%-{$max}s</info> %s%s", $argument->getName(), $description, $default);
             }
 
             $messages[] = '';
@@ -182,7 +182,7 @@ abstract class Command extends BaseCommand
 
                 $optionMax = $max - \strlen($option->getName()) - 2;
                 $messages[] = \sprintf(
-                    " <info>%s</info> %-${optionMax}s%s%s%s",
+                    " <info>%s</info> %-{$optionMax}s%s%s%s",
                     '--'.$option->getName(),
                     $option->getShortcut() ? \sprintf('(-%s) ', $option->getShortcut()) : '',
                     $description,

--- a/src/Formatter/CodeFormatter.php
+++ b/src/Formatter/CodeFormatter.php
@@ -302,7 +302,7 @@ class CodeFormatter implements ReflectorFormatter
                 $mark = ($markLine === $lineNum) ? self::LINE_MARKER : self::NO_LINE_MARKER;
             }
 
-            yield \sprintf("%s<aside>%${pad}s</aside>: %s", $mark, $lineNum, $line);
+            yield \sprintf("%s<aside>%{$pad}s</aside>: %s", $mark, $lineNum, $line);
         }
     }
 


### PR DESCRIPTION
In PHP 8.2, `${var}` string interpolation is deprecated. This updates such patterns to use `{$var}` pattern.

See:
 - [PHP.Watch: `${var}` string interpolation is deprecated](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)
 - [wiki.php.net RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)