### PR TITLE
adding :q shortcut for VIM users

### DIFF
--- a/src/Command/ExitCommand.php
+++ b/src/Command/ExitCommand.php
@@ -29,7 +29,7 @@ class ExitCommand extends Command
     {
         $this
             ->setName('exit')
-            ->setAliases(['quit', 'q'])
+            ->setAliases(['quit', 'q', ':q'])
             ->setDefinition([])
             ->setDescription('End the current session and return to caller.')
             ->setHelp(


### PR DESCRIPTION
A true VIM user will think of this command when leaving any sort of window in OS. 
It would be great to have it here too.