### PR TITLE
Close the pipe if the pager process goes wrong

### DIFF
--- a/src/Output/ProcOutputPager.php
+++ b/src/Output/ProcOutputPager.php
@@ -54,6 +54,7 @@ class ProcOutputPager extends StreamOutput implements OutputPager
         if (false === @\fwrite($pipe, $message.($newline ? \PHP_EOL : ''))) {
             // @codeCoverageIgnoreStart
             // should never happen
+            $this->close();
             throw new \RuntimeException('Unable to write output');
             // @codeCoverageIgnoreEnd
         }


### PR DESCRIPTION
refs https://github.com/bobthecow/psysh/issues/729

By closing the process after the write fails, the new value will be output.