### PR TITLE
Fix return type of Readline::getAutocompleter()

### DIFF
--- a/src/Readline/Hoa/Readline.php
+++ b/src/Readline/Hoa/Readline.php
@@ -431,8 +431,10 @@ class Readline
 
     /**
      * Get the autocompleter.
+     *
+     * @return ?Autocompleter
      */
-    public function getAutocompleter(): ?Autocompleter
+    public function getAutocompleter()
     {
         return $this->_autocompleter;
     }

--- a/src/Readline/Hoa/Readline.php
+++ b/src/Readline/Hoa/Readline.php
@@ -432,7 +432,7 @@ class Readline
     /**
      * Get the autocompleter.
      */
-    public function getAutocompleter(): Autocompleter
+    public function getAutocompleter(): ?Autocompleter
     {
         return $this->_autocompleter;
     }


### PR DESCRIPTION
I get an error when I press TAB while using Userland readline.

<img width="1644" alt="スクリーンショット 2022-07-06 1 06 05" src="https://user-images.githubusercontent.com/822086/177370480-b3cdfa3e-7b6c-4409-bdc1-a1f8ef16a49f.png">
