### PR TITLE
Improves console output

### DIFF
--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -218,8 +218,6 @@ class ShellOutput extends ConsoleOutput
         $formatter->setStyle('inline_html', new OutputFormatterStyle('cyan'));
     }
 
-
-
     /**
      * Checks if the "gray" color exists on the output.
      *

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -176,13 +176,17 @@ class ShellOutput extends ConsoleOutput
     {
         $formatter = $this->getFormatter();
         $errorFormatter = $this->getErrorOutput()->getFormatter();
+        $grayExists = $this->grayExists();
 
+        $formatter->setStyle('info', new OutputFormatterStyle('white', 'blue', ['bold']));
+        $errorFormatter->setStyle('info', new OutputFormatterStyle('white', 'blue', ['bold']));
         $formatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
         $errorFormatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
         $formatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
         $errorFormatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
+        $formatter->setStyle('whisper', new OutputFormatterStyle($grayExists ? 'gray' : 'blue'));
+        $errorFormatter->setStyle('whisper', new OutputFormatterStyle($grayExists ? 'gray' : 'blue'));
 
-        $formatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : 'blue'));
         $formatter->setStyle('aside', new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong', new OutputFormatterStyle(null, null, ['bold']));
         $formatter->setStyle('return', new OutputFormatterStyle('cyan'));

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -229,7 +229,7 @@ class ShellOutput extends ConsoleOutput
     {
         try {
             $this->write('<fg=gray></>');
-        } catch (InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             return false;
         }
 

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -178,14 +178,14 @@ class ShellOutput extends ConsoleOutput
         $errorFormatter = $this->getErrorOutput()->getFormatter();
         $grayExists = $this->grayExists();
 
-        $formatter->setStyle('info', new OutputFormatterStyle('white', 'blue', ['bold']));
-        $errorFormatter->setStyle('info', new OutputFormatterStyle('white', 'blue', ['bold']));
-        $formatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
-        $errorFormatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
-        $formatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
-        $errorFormatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
-        $formatter->setStyle('whisper', new OutputFormatterStyle($grayExists ? 'gray' : 'blue'));
-        $errorFormatter->setStyle('whisper', new OutputFormatterStyle($grayExists ? 'gray' : 'blue'));
+        $formatter->setStyle('info', $outputFormatter = new OutputFormatterStyle('white', 'blue', ['bold']));
+        $errorFormatter->setStyle('info', $outputFormatter);
+        $formatter->setStyle('warning', $outputFormatter = new OutputFormatterStyle('black', 'yellow'));
+        $errorFormatter->setStyle('warning', $outputFormatter);
+        $formatter->setStyle('error', $outputFormatter = new OutputFormatterStyle('white', 'red', ['bold']));
+        $errorFormatter->setStyle('error', $outputFormatter);
+        $formatter->setStyle('whisper', $outputFormatter = new OutputFormatterStyle($grayExists ? 'gray' : 'blue'));
+        $errorFormatter->setStyle('whisper', $outputFormatter);
 
         $formatter->setStyle('aside', new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong', new OutputFormatterStyle(null, null, ['bold']));

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -181,9 +181,8 @@ class ShellOutput extends ConsoleOutput
         $errorFormatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
         $formatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
         $errorFormatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
-        $formatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : null));
-        $errorFormatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : null));
 
+        $formatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : 'blue'));
         $formatter->setStyle('aside', new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong', new OutputFormatterStyle(null, null, ['bold']));
         $formatter->setStyle('return', new OutputFormatterStyle('cyan'));

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -181,6 +181,8 @@ class ShellOutput extends ConsoleOutput
         $errorFormatter->setStyle('warning', new OutputFormatterStyle('black', 'yellow'));
         $formatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
         $errorFormatter->setStyle('error', new OutputFormatterStyle('white', 'red', ['bold']));
+        $formatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : null));
+        $errorFormatter->setStyle('whisper', new OutputFormatterStyle($this->grayExists() ? 'gray' : null));
 
         $formatter->setStyle('aside', new OutputFormatterStyle('blue'));
         $formatter->setStyle('strong', new OutputFormatterStyle(null, null, ['bold']));
@@ -211,5 +213,23 @@ class ShellOutput extends ConsoleOutput
 
         // Code-specific formatting
         $formatter->setStyle('inline_html', new OutputFormatterStyle('cyan'));
+    }
+
+
+
+    /**
+     * Checks if the "gray" color exists on the output.
+     *
+     * @return bool
+     */
+    private function grayExists(): bool
+    {
+        try {
+            $this->write('<fg=gray></>');
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1223,7 +1223,9 @@ class Shell extends Application
      */
     public function formatException(\Exception $e): string
     {
-        if ($e instanceof PsyException) {
+        if ($e instanceof BreakException) {
+            return sprintf("  <fg=white;bg=blue;options=bold> INFO </> %s.", $e->getRawMessage());
+        } elseif ($e instanceof PsyException) {
             $message = \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine());
             $messageLabel = strtoupper($this->getMessageLabel($e));
         } else {
@@ -1249,10 +1251,6 @@ class Shell extends Application
         $message = str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
 
         $severity = ($e instanceof \ErrorException) ? $this->getSeverity($e) : 'error';
-
-       if ($e instanceof BreakException) {
-            return sprintf("  <fg=white;bg=blue;options=bold> INFO </> %s", $message);
-        }
 
         return \sprintf('  <%s> %s </%s> %s', $severity, $messageLabel, $severity, OutputFormatter::escape($message));
     }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -52,10 +52,10 @@ class Shell extends Application
 {
     const VERSION = 'v0.11.7';
 
-    const PROMPT = '>> ';
-    const BUFF_PROMPT = '.. ';
-    const REPLAY = '-> ';
-    const RETVAL = '=> ';
+    const PROMPT = '> ';
+    const BUFF_PROMPT = '. ';
+    const REPLAY = '- ';
+    const RETVAL = '= ';
 
     private $config;
     private $cleaner;
@@ -1244,9 +1244,6 @@ class Shell extends Application
         if (! empty($message) && ! in_array(substr($message, -1), ['.', '?', '!', ':'])) {
             $message = "$message.";
         }
-
-        // Ensures the given message only contains relative paths...
-        $message = str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
 
         $severity = ($e instanceof \ErrorException) ? $this->getSeverity($e) : 'error';
 

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -27,7 +27,6 @@ use Psy\TabCompletion\Matcher;
 use Psy\VarDumper\PresenterAware;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as BaseCommand;
-use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -1206,7 +1205,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof BreakException) {
-            return \sprintf("  <info> INFO </info> %s.", \rtrim($e->getRawMessage(), '.'));
+            return \sprintf('  <info> INFO </info> %s.', \rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
             $message = $e->getLine() > 1
                 ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1224,7 +1224,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof BreakException) {
-            return \sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', rtrim($e->getRawMessage(), '.'));
+            return \sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', \rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
             $message = $e->getLine() > 1
                 ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1324,7 +1324,6 @@ class Shell extends Application
         }
 
         if ($e instanceof PsyException) {
-            $message = $e->getRawMessage();
             $exceptionShortName = (new \ReflectionClass($e))->getShortName();
             $typeParts = preg_split('/(?=[A-Z])/', $exceptionShortName);
             array_pop($typeParts); // Removes "Exception"

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -27,8 +27,8 @@ use Psy\TabCompletion\Matcher;
 use Psy\VarDumper\PresenterAware;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as BaseCommand;
-use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -1126,7 +1126,7 @@ class Shell extends Application
             $indent = \str_repeat(' ', \strlen(static::RETVAL));
             $formatted = $this->presentValue($ret);
             $formattedRetValue = $this->grayExists()
-                ? sprintf('<fg=gray>%s</>', static::RETVAL)
+                ? \sprintf('<fg=gray>%s</>', static::RETVAL)
                 : static::RETVAL;
 
             $formatted = $formattedRetValue.\str_replace(\PHP_EOL, \PHP_EOL.$indent, $formatted);
@@ -1230,7 +1230,7 @@ class Shell extends Application
                 ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())
                 : \sprintf('%s in %s', $e->getRawMessage(), $e->getFile());
 
-            $messageLabel = strtoupper($this->getMessageLabel($e));
+            $messageLabel = \strtoupper($this->getMessageLabel($e));
         } else {
             $message = $e->getMessage();
             $messageLabel = $this->getMessageLabel($e);
@@ -1243,15 +1243,15 @@ class Shell extends Application
         );
 
         $message = \str_replace(" in eval()'d code", '', $message);
-        $message = trim($message);
+        $message = \trim($message);
 
         // Ensures the given string ends with punctuation...
-        if (! empty($message) && ! in_array(substr($message, -1), ['.', '?', '!', ':'])) {
+        if (!empty($message) && !in_array(substr($message, -1), ['.', '?', '!', ':'])) {
             $message = "$message.";
         }
 
         // Ensures the given message only contains relative paths...
-        $message = str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
+        $message = \str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
 
         $severity = ($e instanceof \ErrorException) ? $this->getSeverity($e) : 'error';
 
@@ -1328,13 +1328,13 @@ class Shell extends Application
 
         if ($e instanceof PsyException) {
             $exceptionShortName = (new \ReflectionClass($e))->getShortName();
-            $typeParts = preg_split('/(?=[A-Z])/', $exceptionShortName);
-            array_pop($typeParts); // Removes "Exception"
+            $typeParts = \preg_split('/(?=[A-Z])/', $exceptionShortName);
+            \array_pop($typeParts); // Removes "Exception"
 
-            return trim(strtoupper(implode(' ', $typeParts)));
+            return \trim(strtoupper(implode(' ', $typeParts)));
         }
 
-        return get_class($e);
+        return \get_class($e);
     }
 
     /**

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1224,7 +1224,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof BreakException) {
-            return sprintf("  <fg=white;bg=blue;options=bold> INFO </> %s.", $e->getRawMessage());
+            return sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
             $message = \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine());
             $messageLabel = strtoupper($this->getMessageLabel($e));

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1224,7 +1224,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof PsyException) {
-            $message = $e->getRawMessage();
+            $message = \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine());
             $messageLabel = strtoupper($this->getMessageLabel($e));
         } else {
             $message = $e->getMessage();
@@ -1244,6 +1244,9 @@ class Shell extends Application
         if (! empty($message) && ! in_array(substr($message, -1), ['.', '?', '!', ':'])) {
             $message = "$message.";
         }
+
+        // Ensures the given message only contains relative paths...
+        $message = str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
 
         $severity = ($e instanceof \ErrorException) ? $this->getSeverity($e) : 'error';
 

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1125,9 +1125,7 @@ class Shell extends Application
         } else {
             $indent = \str_repeat(' ', \strlen(static::RETVAL));
             $formatted = $this->presentValue($ret);
-            $formattedRetValue = $this->grayExists()
-                ? \sprintf('<fg=gray>%s</>', static::RETVAL)
-                : static::RETVAL;
+            $formattedRetValue = \sprintf('<whisper>%s</whisper>', static::RETVAL);
 
             $formatted = $formattedRetValue.\str_replace(\PHP_EOL, \PHP_EOL.$indent, $formatted);
         }
@@ -1137,22 +1135,6 @@ class Shell extends Application
         } else {
             $this->output->writeln($formatted);
         }
-    }
-
-    /**
-     * Checks if the "gray" color exists on the output.
-     *
-     * @return bool
-     */
-    private function grayExists(): bool
-    {
-        try {
-            $this->output->write('<fg=gray></>');
-        } catch (InvalidArgumentException $e) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -1491,7 +1473,7 @@ class Shell extends Application
         if (!empty($this->inputBuffer)) {
             $line = \array_shift($this->inputBuffer);
             if (!$line instanceof SilentInput) {
-                $this->output->writeln(\sprintf('<aside>%s %s</aside>', static::REPLAY, OutputFormatter::escape($line)));
+                $this->output->writeln(\sprintf('<whisper>%s</whisper><aside>%s</aside>', static::REPLAY, OutputFormatter::escape($line)));
             }
 
             return $line;
@@ -1519,7 +1501,7 @@ class Shell extends Application
      */
     protected function getHeader(): string
     {
-        return \sprintf('<fg=cyan;options=bold>%s by Justin Hileman</>', $this->getVersion());
+        return \sprintf('<whisper>%s by Justin Hileman</whisper>', $this->getVersion());
     }
 
     /**

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -52,10 +52,10 @@ class Shell extends Application
 {
     const VERSION = 'v0.11.7';
 
-    const PROMPT = '> ';
-    const BUFF_PROMPT = '. ';
-    const REPLAY = '--> ';
-    const RETVAL = '';
+    const PROMPT = '>> ';
+    const BUFF_PROMPT = '.. ';
+    const REPLAY = '-> ';
+    const RETVAL = '=> ';
 
     private $config;
     private $cleaner;
@@ -1123,10 +1123,13 @@ class Shell extends Application
         if ($rawOutput) {
             $formatted = \var_export($ret, true);
         } else {
+            $indent = \str_repeat(' ', \strlen(static::RETVAL));
             $formatted = $this->presentValue($ret);
-            $formatted = static::RETVAL.implode("\n", array_map(function ($line) {
-                return $this->grayExists() ? "<fg=gray;>│ </>$line" : "│ $line";
-            }, explode("\n", $formatted)));
+            $formattedRetValue = $this->grayExists()
+                ? sprintf('<fg=gray>%s</>', static::RETVAL)
+                : static::RETVAL;
+
+            $formatted = $formattedRetValue.\str_replace(\PHP_EOL, \PHP_EOL.$indent, $formatted);
         }
 
         if ($this->output instanceof ShellOutput) {

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1080,7 +1080,7 @@ class Shell extends Application
             // Write an extra newline if stdout didn't end with one
             if ($this->outputWantsNewline) {
                 if (!$this->config->rawOutput() && !$this->config->outputIsPiped()) {
-                    $this->output->writeln(\sprintf('<aside>%s</aside>', $this->config->useUnicode() ? '⏎' : '\\n'));
+                    $this->output->writeln(\sprintf('<whisper>%s</whisper>', $this->config->useUnicode() ? '⏎' : '\\n'));
                 } else {
                     $this->output->writeln('');
                 }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1224,7 +1224,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof BreakException) {
-            return sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', rtrim($e->getRawMessage(), '.'));
+            return \sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
             $message = $e->getLine() > 1
                 ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())
@@ -1246,12 +1246,12 @@ class Shell extends Application
         $message = \trim($message);
 
         // Ensures the given string ends with punctuation...
-        if (!empty($message) && !in_array(substr($message, -1), ['.', '?', '!', ':'])) {
+        if (!empty($message) && !\in_array(\substr($message, -1), ['.', '?', '!', ':'])) {
             $message = "$message.";
         }
 
         // Ensures the given message only contains relative paths...
-        $message = \str_replace(getcwd().DIRECTORY_SEPARATOR, '', $message);
+        $message = \str_replace(\getcwd().\DIRECTORY_SEPARATOR, '', $message);
 
         $severity = ($e instanceof \ErrorException) ? $this->getSeverity($e) : 'error';
 
@@ -1331,7 +1331,7 @@ class Shell extends Application
             $typeParts = \preg_split('/(?=[A-Z])/', $exceptionShortName);
             \array_pop($typeParts); // Removes "Exception"
 
-            return \trim(strtoupper(implode(' ', $typeParts)));
+            return \trim(\strtoupper(\implode(' ', $typeParts)));
         }
 
         return \get_class($e);

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1206,7 +1206,7 @@ class Shell extends Application
     public function formatException(\Exception $e): string
     {
         if ($e instanceof BreakException) {
-            return \sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', \rtrim($e->getRawMessage(), '.'));
+            return \sprintf("  <info> INFO </info> %s.", \rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
             $message = $e->getLine() > 1
                 ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1226,7 +1226,10 @@ class Shell extends Application
         if ($e instanceof BreakException) {
             return sprintf('  <fg=white;bg=blue;options=bold> INFO </> %s.', rtrim($e->getRawMessage(), '.'));
         } elseif ($e instanceof PsyException) {
-            $message = \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine());
+            $message = $e->getLine() > 1
+                ? \sprintf('%s in %s on line %d', $e->getRawMessage(), $e->getFile(), $e->getLine())
+                : \sprintf('%s in %s', $e->getRawMessage(), $e->getFile());
+
             $messageLabel = strtoupper($this->getMessageLabel($e));
         } else {
             $message = $e->getMessage();

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -264,12 +264,9 @@ class ShellTest extends TestCase
         \rewind($stream);
         $streamContents = \stream_get_contents($stream);
 
-        $this->assertSame(<<<EOF
-
-          <warning> $label </warning> wheee in src/Shell.php on line 13.
-
-
-        EOF, $streamContents);
+        $this->assertStringContainsString($label, $streamContents);
+        $this->assertStringContainsString('wheee', $streamContents);
+        $this->assertStringContainsString('line 13', $streamContents);
     }
 
     public function notSoBadErrors()

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -239,7 +239,7 @@ class ShellTest extends TestCase
 
         $this->assertSame(<<<EOF
 
-           PARSE ERROR  PHP Parse error: message.
+           PARSE ERROR  PHP Parse error: message in test/ShellTest.php on line 224.
 
 
         EOF, $streamContents);
@@ -266,13 +266,10 @@ class ShellTest extends TestCase
 
         $this->assertSame(<<<EOF
 
-          <warning> $label </warning> wheee.
+          <warning> $label </warning> wheee in src/Shell.php on line 13.
 
 
         EOF, $streamContents);
-
-        $this->assertStringContainsString('wheee', $streamContents);
-        $this->assertStringNotContainsString('line 13', $streamContents);
     }
 
     public function notSoBadErrors()
@@ -525,7 +522,7 @@ class ShellTest extends TestCase
         $shell = new Shell($this->getConfig());
         $shell->setOutput($output);
 
-        $shell->writeException(new BreakException('yeah.'));
+        $shell->writeException(new BreakException('yeah'));
         \rewind($stream);
         $this->assertSame(<<<EOF
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -476,8 +476,8 @@ class ShellTest extends TestCase
     public function getReturnValues()
     {
         return [
-            ['{{return value}}', "│ \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
-            [1, "│ \033[35m1\033[39m".\PHP_EOL],
+            ['{{return value}}', "=> \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
+            [1, "=> \033[35m1\033[39m".\PHP_EOL],
         ];
     }
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -473,8 +473,8 @@ class ShellTest extends TestCase
     public function getReturnValues()
     {
         return [
-            ['{{return value}}', "= \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
-            [1, "= \033[35m1\033[39m".\PHP_EOL],
+            ['{{return value}}', "<whisper>= </whisper>\"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
+            [1, "<whisper>= </whisper>\033[35m1\033[39m".\PHP_EOL],
         ];
     }
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -237,12 +237,14 @@ class ShellTest extends TestCase
         \rewind($stream);
         $streamContents = \stream_get_contents($stream);
 
-        $this->assertSame(<<<EOF
+        $expected = <<<EOF
 
    PARSE ERROR  PHP Parse error: message in test/ShellTest.php on line 224.
 
 
-EOF, $streamContents);
+EOF;
+
+        $this->assertSame($expected, $streamContents);
     }
 
     /**
@@ -521,24 +523,29 @@ EOF, $streamContents);
 
         $shell->writeException(new BreakException('yeah'));
         \rewind($stream);
-        $this->assertSame(<<<EOF
+
+        $expected = <<<EOF
 
    INFO  yeah.
 
 
-EOF, \stream_get_contents($stream));
+EOF;
+
+        $this->assertSame($expected, \stream_get_contents($stream));
     }
 
     public function getRenderedExceptions()
     {
-        return [[
-            new \Exception('{{message}}'),
-            <<<EOF
+        $expected = <<<EOF
 
    Exception  {{message}}.
 
 
-EOF,
+EOF;
+
+        return [[
+            new \Exception('{{message}}'),
+            $expected,
         ]];
     }
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -239,10 +239,10 @@ class ShellTest extends TestCase
 
         $this->assertSame(<<<EOF
 
-           PARSE ERROR  PHP Parse error: message in test/ShellTest.php on line 224.
+   PARSE ERROR  PHP Parse error: message in test/ShellTest.php on line 224.
 
 
-        EOF, $streamContents);
+EOF, $streamContents);
     }
 
     /**
@@ -523,10 +523,10 @@ class ShellTest extends TestCase
         \rewind($stream);
         $this->assertSame(<<<EOF
 
-           INFO  yeah.
+   INFO  yeah.
 
 
-        EOF, \stream_get_contents($stream));
+EOF, \stream_get_contents($stream));
     }
 
     public function getRenderedExceptions()
@@ -535,10 +535,10 @@ class ShellTest extends TestCase
             new \Exception('{{message}}'),
             <<<EOF
 
-               Exception  {{message}}.
+   Exception  {{message}}.
 
 
-            EOF,
+EOF,
         ]];
     }
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -237,9 +237,12 @@ class ShellTest extends TestCase
         \rewind($stream);
         $streamContents = \stream_get_contents($stream);
 
-        $this->assertStringContainsString('PHP Parse error', $streamContents);
-        $this->assertStringContainsString('message', $streamContents);
-        $this->assertStringContainsString('line 13', $streamContents);
+        $this->assertSame(<<<EOF
+
+           PARSE ERROR  PHP Parse error: message.
+
+
+        EOF, $streamContents);
     }
 
     /**
@@ -261,22 +264,28 @@ class ShellTest extends TestCase
         \rewind($stream);
         $streamContents = \stream_get_contents($stream);
 
-        $this->assertStringContainsString($label, $streamContents);
+        $this->assertSame(<<<EOF
+
+          <warning> $label </warning> wheee.
+
+
+        EOF, $streamContents);
+
         $this->assertStringContainsString('wheee', $streamContents);
-        $this->assertStringContainsString('line 13', $streamContents);
+        $this->assertStringNotContainsString('line 13', $streamContents);
     }
 
     public function notSoBadErrors()
     {
         return [
-            [\E_WARNING, 'PHP Warning:'],
-            [\E_NOTICE, 'PHP Notice:'],
-            [\E_CORE_WARNING, 'PHP Warning:'],
-            [\E_COMPILE_WARNING, 'PHP Warning:'],
-            [\E_USER_WARNING, 'PHP Warning:'],
-            [\E_USER_NOTICE, 'PHP Notice:'],
-            [\E_DEPRECATED, 'PHP Deprecated:'],
-            [\E_USER_DEPRECATED, 'PHP Deprecated:'],
+            [\E_WARNING, 'WARNING'],
+            [\E_NOTICE, 'NOTICE'],
+            [\E_CORE_WARNING, 'CORE WARNING'],
+            [\E_COMPILE_WARNING, 'COMPILE WARNING'],
+            [\E_USER_WARNING, 'USER WARNING'],
+            [\E_USER_NOTICE, 'USER NOTICE'],
+            [\E_DEPRECATED, 'DEPRECATED'],
+            [\E_USER_DEPRECATED, 'USER DEPRECATED'],
         ];
     }
 
@@ -467,8 +476,8 @@ class ShellTest extends TestCase
     public function getReturnValues()
     {
         return [
-            ['{{return value}}', "=> \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
-            [1, "=> \033[35m1\033[39m".\PHP_EOL],
+            ['{{return value}}', "│ \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
+            [1, "│ \033[35m1\033[39m".\PHP_EOL],
         ];
     }
 
@@ -518,14 +527,25 @@ class ShellTest extends TestCase
 
         $shell->writeException(new BreakException('yeah.'));
         \rewind($stream);
-        $this->assertSame('Exit:  yeah.'.\PHP_EOL, \stream_get_contents($stream));
+        $this->assertSame(<<<EOF
+
+           INFO  yeah.
+
+
+        EOF, \stream_get_contents($stream));
     }
 
     public function getRenderedExceptions()
     {
-        return [
-            [new \Exception('{{message}}'), "Exception with message '{{message}}'".\PHP_EOL],
-        ];
+        return [[
+            new \Exception('{{message}}'),
+            <<<EOF
+
+               Exception  {{message}}.
+
+
+            EOF,
+        ]];
     }
 
     /**

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -476,8 +476,8 @@ class ShellTest extends TestCase
     public function getReturnValues()
     {
         return [
-            ['{{return value}}', "=> \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
-            [1, "=> \033[35m1\033[39m".\PHP_EOL],
+            ['{{return value}}', "= \"\033[32m{{return value}}\033[39m\"".\PHP_EOL],
+            [1, "= \033[35m1\033[39m".\PHP_EOL],
         ];
     }
 


### PR DESCRIPTION
After https://github.com/laravel/tinker/pull/152, as requested, I've made this pull request that updates the console output of the shell class. Here are the changes, and feel free to "check" the ones you agree with, and leave uncheck the changes you think still need some discussion.

- [x] As requested, we've left the library's author name unchanged, and simply updated the color from "blue" to "cyan".
- [ ] Next, the `PROMPT`, `BUFF_PROMPT`, `REPLAY, and `RETVAL`, have been simplified to a single `char`. Also, the `RETVAL` is displayed on `gray`, so the output result gets highlighted.
- [ ] After, when errors/warnings occur, I've added margin-top and margin-bottom ( a new line ), so the terminal has some space to breathe.
- [x] Also, the "Goodbye" message, or any message coming from "BreakException" are now displayed as regular "INFO" information, as they are not errors.
- [x] Next, I've displayed the errors differently, using a "CLASS_NAME" followed by the original message for regular exceptions, and using "ERROR_TYPE" followed by the original message for PHP errors/warnings.
- [x] I've removed the "in Psy Shell code" wording, as it doesn't add anything.
- [x] Finally, I've ensured error/warnings messages **always** end with a "dot", and contain relative paths instead of absolute paths.


Here is the described changes, but comparing the before vs after:

<img width="1747" alt="1" src="https://user-images.githubusercontent.com/5457236/181797815-bcb5fd4e-d537-43d6-b112-e7e511dbe5e4.png">
<img width="1757" alt="2" src="https://user-images.githubusercontent.com/5457236/181797835-36009539-d574-44ad-9671-fe8e434ecd6c.png">
<img width="1770" alt="3" src="https://user-images.githubusercontent.com/5457236/181797840-f341368c-4f93-4553-8ecb-6236a8ba86fb.png">
<img width="1744" alt="4" src="https://user-images.githubusercontent.com/5457236/181797846-7a32f0c6-419e-42f2-9960-a85aa77a5240.png">
<img width="1747" alt="5" src="https://user-images.githubusercontent.com/5457236/181797852-4244e5f8-b3bc-4e6e-afc4-0d5722709c1f.png">

