### PR TITLE
Add support for disabling the header in interactive sessions

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -53,6 +53,7 @@ class Configuration
         'compactOutput',
         'dataDir',
         'defaultIncludes',
+        'showHeader',
         'eraseDuplicates',
         'errorLoggingLevel',
         'forceArrayIndexes',
@@ -86,6 +87,7 @@ class Configuration
     /** @var string|false */
     private $historyFile;
     private $historySize;
+    private $showHeader = true;
     private $eraseDuplicates;
     private $manualDbFile;
     private $hasReadline;
@@ -1651,6 +1653,26 @@ class Configuration
     public function getStartupMessage()
     {
         return $this->startupMessage;
+    }
+
+    /**
+     * Show or hide the header message in interactive sessions.
+     *
+     * @param bool $showHeader
+     */
+    public function setShowHeader(bool $showHeader)
+    {
+        $this->showHeader = (bool) $showHeader;
+    }
+
+    /**
+     * Determine if the header has been disabled.
+     *
+     * @return bool
+     */
+    public function showHeader(): bool
+    {
+        return $this->showHeader;
     }
 
     /**

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -372,7 +372,7 @@ class Shell extends Application
         $this->initializeTabCompletion();
         $this->readline->readHistory();
 
-        $this->output->writeln($this->getHeader());
+        if($this->config->showHeader()) $this->output->writeln($this->getHeader());
         $this->writeVersionInfo();
         $this->writeStartupMessage();
 
@@ -407,7 +407,7 @@ class Shell extends Application
 
         // If raw output is enabled (or output is piped) we don't want startup messages.
         if (!$rawOutput && !$this->config->outputIsPiped()) {
-            $this->output->writeln($this->getHeader());
+            if($this->config->showHeader()) $this->output->writeln($this->getHeader());
             $this->writeVersionInfo();
             $this->writeStartupMessage();
         }

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -42,6 +42,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($config->requireSemicolons());
         $this->assertSame(Configuration::COLOR_MODE_AUTO, $config->colorMode());
         $this->assertNull($config->getStartupMessage());
+        $this->assertTrue($config->showHeader());
     }
 
     public function testGettersAndSetters()
@@ -72,6 +73,7 @@ class ConfigurationTest extends TestCase
             'errorLoggingLevel' => \E_ERROR | \E_WARNING,
             'colorMode'         => Configuration::COLOR_MODE_FORCED,
             'startupMessage'    => 'Psysh is awesome!',
+            'showHeader'        => false
         ]);
 
         $this->assertFalse($config->useReadline());
@@ -82,6 +84,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame(\E_ERROR | \E_WARNING, $config->errorLoggingLevel());
         $this->assertSame(Configuration::COLOR_MODE_FORCED, $config->colorMode());
         $this->assertSame('Psysh is awesome!', $config->getStartupMessage());
+        $this->assertFalse($config->showHeader());
     }
 
     public function testLoadConfigFile()


### PR DESCRIPTION
This is a simple patch that allows for a new configuration variable, `showHeader`, which can be set to false to disable the `Psy Shell v0.11.8 (PHP 8.1.10 — cli) by Justin Hileman` header in interactive sessions.

The header is nice, but honestly some times I just want to jump in and out of psysh with the extra row cluttering up the terminal history, so my `showHeader` option pairs nicely with the new compact mode.

Plus, now with `'showHeader'=>false, 'startupMessage'=>"This is my startup message, thanks Justin Hileman for PySH!"` in the config file, you can customize the "header" even more than before.

Thanks for the hard work on this project and thanks for considering my pull request 👍🏻