### PR TITLE
[Fix] Docblock::tag(...) throws TypeError

### DIFF
--- a/src/Util/Docblock.php
+++ b/src/Util/Docblock.php
@@ -212,9 +212,9 @@ class Docblock
      *
      * @param string $tag
      *
-     * @return array
+     * @return array|null
      */
-    public function tag(string $tag): array
+    public function tag(string $tag): ?array
     {
         return $this->hasTag($tag) ? $this->tags[$tag] : null;
     }


### PR DESCRIPTION
The `Docblock::tag(...)` method throws a TypeError when specifying a non-existent tag.

Fixed the method to allow for a `null` return alongside the normal `array` as that is what the intentions of the code suggests.