### PR TITLE
Replace undefined DS constant

### DIFF
--- a/src/Readline/Hoa/ProtocolNodeLibrary.php
+++ b/src/Readline/Hoa/ProtocolNodeLibrary.php
@@ -47,7 +47,7 @@ class ProtocolNodeLibrary extends ProtocolNode
     public function reach(string $queue = null)
     {
         $withComposer = \class_exists('Composer\Autoload\ClassLoader', false) ||
-            ('cli' === \PHP_SAPI && \file_exists(__DIR__.DS.'..'.DS.'..'.DS.'..'.DS.'..'.DS.'autoload.php'));
+            ('cli' === \PHP_SAPI && \file_exists(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'autoload.php'));
 
         if ($withComposer) {
             return parent::reach($queue);


### PR DESCRIPTION
Hoa project defines DS as a shorthand for DIRECTORY_SEPARATOR, while psysh tends to use \DIRECTORY_SEPARATOR.

This fixes the following issue:

Error: Undefined constant "Psy\Readline\Hoa\DS" in phar:///opt/psysh/psysh/src/Readline/Hoa/ProtocolNodeLibrary.php on line 9

Fixes #757.