### PR TITLE
Use getenv() to fetch environment variable when absent from $_SERVER

### DIFF
--- a/src/ConfigPaths.php
+++ b/src/ConfigPaths.php
@@ -34,7 +34,8 @@ class ConfigPaths
     public function __construct(array $overrides = [], EnvInterface $env = null)
     {
         $this->overrideDirs($overrides);
-        $this->env = $env ?: new SuperglobalsEnv();
+
+        $this->env = $env ?: (\PHP_SAPI === 'cli-server' ? new SystemEnv() : new SuperglobalsEnv());
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -147,6 +147,8 @@ class Configuration
             $this->configFile = $config['configFile'];
         } elseif (isset($_SERVER['PSYSH_CONFIG']) && $_SERVER['PSYSH_CONFIG']) {
             $this->configFile = $_SERVER['PSYSH_CONFIG'];
+        } elseif (\PHP_SAPI === 'cli-server' && ($configFile = \getenv('PSYSH_CONFIG'))) {
+            $this->configFile = $configFile;
         }
 
         // legacy baseDir option

--- a/src/SystemEnv.php
+++ b/src/SystemEnv.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2023 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy;
+
+/**
+ * Environment variables implementation via getenv().
+ */
+class SystemEnv implements EnvInterface
+{
+    /**
+     * Get an environment variable by name.
+     *
+     * @return string|null
+     */
+    public function get(string $key)
+    {
+        if (isset($_SERVER[$key]) && $_SERVER[$key]) {
+            return $_SERVER[$key];
+        }
+
+        $result = \getenv($key);
+
+        return $result === false ? null : $result;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -155,6 +155,9 @@ if (!\function_exists('Psy\\info')) {
 
         $config = $lastConfig ?: new Configuration();
         $configEnv = (isset($_SERVER['PSYSH_CONFIG']) && $_SERVER['PSYSH_CONFIG']) ? $_SERVER['PSYSH_CONFIG'] : false;
+        if ($configEnv === false && \PHP_SAPI === 'cli-server') {
+            $configEnv = \getenv('PSYSH_CONFIG');
+        }
 
         $shellInfo = [
             'PsySH version' => Shell::VERSION,


### PR DESCRIPTION
At present, PsySH checks for environment variables in $_SERVER. As a result, when using PsySH from the `cli-server` SAPI, it may fail to look up the value of $HOME and thereby try to create the `~/.config/psysh` directory in `/` (which fails unless the user is root).

This PR fixes the issue by falling back on `getenv()` to find out the value of the environment variable.