### PR TITLE
Fix undefined array key when argv doesn't exists

### DIFF
--- a/src/Readline/Hoa/Protocol.php
+++ b/src/Readline/Hoa/Protocol.php
@@ -87,7 +87,7 @@ class Protocol extends ProtocolNode
     protected function initialize()
     {
         $root = \dirname(__DIR__, 3);
-        $argv0 = \realpath($_SERVER['argv'][0]);
+        $argv0 = isset($_SERVER['argv'][0]) ? \realpath($_SERVER['argv'][0]) : false;
 
         $cwd =
             'cli' === \PHP_SAPI


### PR DESCRIPTION
In some cases `$_SERVER['argv']` may not be set (I hit this issue with a project).