### PR TITLE
Avoid internal call to deprecated getVersion() method

### DIFF
--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1509,7 +1509,7 @@ class Shell extends Application
      */
     protected function getHeader(): string
     {
-        return \sprintf('<whisper>%s by Justin Hileman</whisper>', $this->getVersion());
+        return \sprintf('<whisper>%s by Justin Hileman</whisper>', self::getVersionHeader($this->config->useUnicode()));
     }
 
     /**


### PR DESCRIPTION
After updating to v0.12.0, I get a deprecation warning emitted when running the shell. I have mine set up in a light Doctrine Console wrapper, though I suspect that's not relevant.

I tested this patch in my local vendor code and saw no negative impact, and it removed the deprecation warning.