### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/CodeCleaner.php
+++ b/src/CodeCleaner.php
@@ -65,7 +65,7 @@ class CodeCleaner
      * @param bool               $yolo        run without input validation
      * @param bool               $strictTypes enforce strict types by default
      */
-    public function __construct(Parser $parser = null, Printer $printer = null, NodeTraverser $traverser = null, bool $yolo = false, bool $strictTypes = false)
+    public function __construct(?Parser $parser = null, ?Printer $printer = null, ?NodeTraverser $traverser = null, bool $yolo = false, bool $strictTypes = false)
     {
         $this->yolo = $yolo;
         $this->strictTypes = $strictTypes;
@@ -284,7 +284,7 @@ class CodeCleaner
      *
      * @param array|null $namespace (default: null)
      */
-    public function setNamespace(array $namespace = null)
+    public function setNamespace(?array $namespace = null)
     {
         $this->namespace = $namespace;
     }

--- a/src/Command/CodeArgumentParser.php
+++ b/src/Command/CodeArgumentParser.php
@@ -22,7 +22,7 @@ class CodeArgumentParser
 {
     private $parser;
 
-    public function __construct(Parser $parser = null)
+    public function __construct(?Parser $parser = null)
     {
         $this->parser = $parser ?? (new ParserFactory())->createParser();
     }

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -30,7 +30,7 @@ abstract class Command extends BaseCommand
      *
      * @api
      */
-    public function setApplication(Application $application = null): void
+    public function setApplication(?Application $application = null): void
     {
         if ($application !== null && !$application instanceof Shell) {
             throw new \InvalidArgumentException('PsySH Commands require an instance of Psy\Shell');

--- a/src/Command/EditCommand.php
+++ b/src/Command/EditCommand.php
@@ -115,7 +115,7 @@ class EditCommand extends Command implements ContextAware
      * @param bool        $noExecOption
      * @param string|null $filePath
      */
-    private function shouldExecuteFile(bool $execOption, bool $noExecOption, string $filePath = null): bool
+    private function shouldExecuteFile(bool $execOption, bool $noExecOption, ?string $filePath = null): bool
     {
         if ($execOption) {
             return true;
@@ -136,7 +136,7 @@ class EditCommand extends Command implements ContextAware
      *
      * @throws \InvalidArgumentException If the variable is not found in the current context
      */
-    private function extractFilePath(string $fileArgument = null)
+    private function extractFilePath(?string $fileArgument = null)
     {
         // If the file argument was a variable, get it from the context
         if ($fileArgument !== null &&

--- a/src/Command/ListCommand/ClassConstantEnumerator.php
+++ b/src/Command/ListCommand/ClassConstantEnumerator.php
@@ -21,7 +21,7 @@ class ClassConstantEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // only list constants when a Reflector is present.
         if ($reflector === null) {

--- a/src/Command/ListCommand/ClassEnumerator.php
+++ b/src/Command/ListCommand/ClassEnumerator.php
@@ -22,7 +22,7 @@ class ClassEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // if we have a reflector, ensure that it's a namespace reflector
         if (($target !== null || $reflector !== null) && !$reflector instanceof ReflectionNamespace) {
@@ -66,7 +66,7 @@ class ClassEnumerator extends Enumerator
      *
      * @return array
      */
-    protected function filterClasses(string $key, array $classes, bool $internal, bool $user, string $prefix = null): array
+    protected function filterClasses(string $key, array $classes, bool $internal, bool $user, ?string $prefix = null): array
     {
         $ret = [];
 

--- a/src/Command/ListCommand/ConstantEnumerator.php
+++ b/src/Command/ListCommand/ConstantEnumerator.php
@@ -49,7 +49,7 @@ class ConstantEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // if we have a reflector, ensure that it's a namespace reflector
         if (($target !== null || $reflector !== null) && !$reflector instanceof ReflectionNamespace) {
@@ -122,7 +122,7 @@ class ConstantEnumerator extends Enumerator
      *
      * @return array
      */
-    protected function getConstants(string $category = null): array
+    protected function getConstants(?string $category = null): array
     {
         if (!$category) {
             return \get_defined_constants();

--- a/src/Command/ListCommand/Enumerator.php
+++ b/src/Command/ListCommand/Enumerator.php
@@ -54,7 +54,7 @@ abstract class Enumerator
      *
      * @return array
      */
-    public function enumerate(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    public function enumerate(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         $this->filter->bind($input);
 
@@ -82,7 +82,7 @@ abstract class Enumerator
      *
      * @return array
      */
-    abstract protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array;
+    abstract protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array;
 
     protected function showItem($name)
     {

--- a/src/Command/ListCommand/FunctionEnumerator.php
+++ b/src/Command/ListCommand/FunctionEnumerator.php
@@ -22,7 +22,7 @@ class FunctionEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // if we have a reflector, ensure that it's a namespace reflector
         if (($target !== null || $reflector !== null) && !$reflector instanceof ReflectionNamespace) {
@@ -67,7 +67,7 @@ class FunctionEnumerator extends Enumerator
      *
      * @return array
      */
-    protected function getFunctions(string $type = null): array
+    protected function getFunctions(?string $type = null): array
     {
         $funcs = \get_defined_functions();
 
@@ -86,7 +86,7 @@ class FunctionEnumerator extends Enumerator
      *
      * @return array
      */
-    protected function prepareFunctions(array $functions, string $prefix = null): array
+    protected function prepareFunctions(array $functions, ?string $prefix = null): array
     {
         \natcasesort($functions);
 

--- a/src/Command/ListCommand/GlobalVariableEnumerator.php
+++ b/src/Command/ListCommand/GlobalVariableEnumerator.php
@@ -21,7 +21,7 @@ class GlobalVariableEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // only list globals when no Reflector is present.
         if ($reflector !== null || $target !== null) {

--- a/src/Command/ListCommand/MethodEnumerator.php
+++ b/src/Command/ListCommand/MethodEnumerator.php
@@ -21,7 +21,7 @@ class MethodEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // only list methods when a Reflector is present.
         if ($reflector === null) {

--- a/src/Command/ListCommand/PropertyEnumerator.php
+++ b/src/Command/ListCommand/PropertyEnumerator.php
@@ -21,7 +21,7 @@ class PropertyEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // only list properties when a Reflector is present.
 

--- a/src/Command/ListCommand/VariableEnumerator.php
+++ b/src/Command/ListCommand/VariableEnumerator.php
@@ -45,7 +45,7 @@ class VariableEnumerator extends Enumerator
     /**
      * {@inheritdoc}
      */
-    protected function listItems(InputInterface $input, \Reflector $reflector = null, $target = null): array
+    protected function listItems(InputInterface $input, ?\Reflector $reflector = null, $target = null): array
     {
         // only list variables when no Reflector is present.
         if ($reflector !== null || $target !== null) {

--- a/src/Command/ThrowUpCommand.php
+++ b/src/Command/ThrowUpCommand.php
@@ -99,7 +99,7 @@ HELP
      *
      * @return Arg[]
      */
-    private function prepareArgs(string $code = null): array
+    private function prepareArgs(?string $code = null): array
     {
         if (!$code) {
             // Default to last exception if nothing else was supplied

--- a/src/Command/TimeitCommand/TimeitVisitor.php
+++ b/src/Command/TimeitCommand/TimeitVisitor.php
@@ -120,7 +120,7 @@ class TimeitVisitor extends NodeVisitorAbstract
      *
      * @param Expr|null $arg
      */
-    private function getEndCall(Expr $arg = null): StaticCall
+    private function getEndCall(?Expr $arg = null): StaticCall
     {
         if ($arg === null) {
             $arg = NoReturnValue::create();

--- a/src/Command/TraceCommand.php
+++ b/src/Command/TraceCommand.php
@@ -92,7 +92,7 @@ HELP
      *
      * @return array Formatted stacktrace lines
      */
-    protected function getBacktrace(\Throwable $e, int $count = null, bool $includePsy = true): array
+    protected function getBacktrace(\Throwable $e, ?int $count = null, bool $includePsy = true): array
     {
         return TraceFormatter::formatTrace($e, $this->filter, $count, $includePsy);
     }

--- a/src/ConfigPaths.php
+++ b/src/ConfigPaths.php
@@ -31,7 +31,7 @@ class ConfigPaths
      * @param string[]     $overrides Directory overrides
      * @param EnvInterface $env
      */
-    public function __construct(array $overrides = [], EnvInterface $env = null)
+    public function __construct(array $overrides = [], ?EnvInterface $env = null)
     {
         $this->overrideDirs($overrides);
 

--- a/src/Exception/BreakException.php
+++ b/src/Exception/BreakException.php
@@ -21,7 +21,7 @@ class BreakException extends \Exception implements Exception
     /**
      * {@inheritdoc}
      */
-    public function __construct($message = '', $code = 0, \Throwable $previous = null)
+    public function __construct($message = '', $code = 0, ?\Throwable $previous = null)
     {
         $this->rawMessage = $message;
         parent::__construct(\sprintf('Exit:  %s', $message), $code, $previous);

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -28,7 +28,7 @@ class ErrorException extends \ErrorException implements Exception
      * @param int|null        $lineno   (default: null)
      * @param \Throwable|null $previous (default: null)
      */
-    public function __construct($message = '', $code = 0, $severity = 1, $filename = null, $lineno = null, \Throwable $previous = null)
+    public function __construct($message = '', $code = 0, $severity = 1, $filename = null, $lineno = null, ?\Throwable $previous = null)
     {
         $this->rawMessage = $message;
 

--- a/src/Exception/FatalErrorException.php
+++ b/src/Exception/FatalErrorException.php
@@ -28,7 +28,7 @@ class FatalErrorException extends \ErrorException implements Exception
      * @param int|null        $lineno   (default: null)
      * @param \Throwable|null $previous (default: null)
      */
-    public function __construct($message = '', $code = 0, $severity = 1, $filename = null, $lineno = null, \Throwable $previous = null)
+    public function __construct($message = '', $code = 0, $severity = 1, $filename = null, $lineno = null, ?\Throwable $previous = null)
     {
         // Since these are basically always PHP Parser Node line numbers, treat -1 as null.
         if ($lineno === -1) {

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -25,7 +25,7 @@ class RuntimeException extends \RuntimeException implements Exception
      * @param int             $code     (default: 0)
      * @param \Throwable|null $previous (default: null)
      */
-    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         $this->rawMessage = $message;
         parent::__construct($message, $code, $previous);

--- a/src/Exception/UnexpectedTargetException.php
+++ b/src/Exception/UnexpectedTargetException.php
@@ -21,7 +21,7 @@ class UnexpectedTargetException extends RuntimeException
      * @param int             $code     (default: 0)
      * @param \Throwable|null $previous (default: null)
      */
-    public function __construct($target, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct($target, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         $this->target = $target;
         parent::__construct($message, $code, $previous);

--- a/src/Formatter/CodeFormatter.php
+++ b/src/Formatter/CodeFormatter.php
@@ -103,7 +103,7 @@ class CodeFormatter implements ReflectorFormatter
      *
      * @return string formatted code
      */
-    public static function formatCode(string $code, int $startLine = 1, int $endLine = null, int $markLine = null): string
+    public static function formatCode(string $code, int $startLine = 1, ?int $endLine = null, ?int $markLine = null): string
     {
         $spans = self::tokenizeSpans($code);
         $lines = self::splitLines($spans, $startLine, $endLine);
@@ -206,7 +206,7 @@ class CodeFormatter implements ReflectorFormatter
      *
      * @return \Generator lines, each an array of [$spanType, $spanText] pairs
      */
-    private static function splitLines(\Generator $spans, int $startLine = 1, int $endLine = null): \Generator
+    private static function splitLines(\Generator $spans, int $startLine = 1, ?int $endLine = null): \Generator
     {
         $lineNum = 1;
         $buffer = [];
@@ -273,7 +273,7 @@ class CodeFormatter implements ReflectorFormatter
      *
      * @return \Generator Numbered, formatted lines
      */
-    private static function numberLines(\Generator $lines, int $markLine = null): \Generator
+    private static function numberLines(\Generator $lines, ?int $markLine = null): \Generator
     {
         $lines = \iterator_to_array($lines);
 

--- a/src/Formatter/TraceFormatter.php
+++ b/src/Formatter/TraceFormatter.php
@@ -29,7 +29,7 @@ class TraceFormatter
      *
      * @return string[] Formatted stacktrace lines
      */
-    public static function formatTrace(\Throwable $throwable, FilterOptions $filter = null, int $count = null, bool $includePsy = true): array
+    public static function formatTrace(\Throwable $throwable, ?FilterOptions $filter = null, ?int $count = null, bool $includePsy = true): array
     {
         if ($cwd = \getcwd()) {
             $cwd = \rtrim($cwd, \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR;

--- a/src/Input/CodeArgument.php
+++ b/src/Input/CodeArgument.php
@@ -39,7 +39,7 @@ class CodeArgument extends InputArgument
      *
      * @throws \InvalidArgumentException When argument mode is not valid
      */
-    public function __construct(string $name, int $mode = null, string $description = '', $default = null)
+    public function __construct(string $name, ?int $mode = null, string $description = '', $default = null)
     {
         if ($mode & InputArgument::IS_ARRAY) {
             throw new \InvalidArgumentException('Argument mode IS_ARRAY is not valid');

--- a/src/Input/FilterOptions.php
+++ b/src/Input/FilterOptions.php
@@ -85,7 +85,7 @@ class FilterOptions
      * @param string $string
      * @param array  $matches
      */
-    public function match(string $string, array &$matches = null): bool
+    public function match(string $string, ?array &$matches = null): bool
     {
         return $this->filter === false || (\preg_match($this->pattern, $string, $matches) xor $this->invert);
     }

--- a/src/Output/ShellOutput.php
+++ b/src/Output/ShellOutput.php
@@ -38,7 +38,7 @@ class ShellOutput extends ConsoleOutput
      * @param OutputFormatterInterface|null $formatter (default: null)
      * @param string|OutputPager|null       $pager     (default: null)
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatterInterface $formatter = null, $pager = null, $theme = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, ?OutputFormatterInterface $formatter = null, $pager = null, $theme = null)
     {
         parent::__construct($verbosity, $decorated, $formatter);
 

--- a/src/Readline/GNUReadline.php
+++ b/src/Readline/GNUReadline.php
@@ -105,7 +105,7 @@ class GNUReadline implements Readline
     /**
      * {@inheritdoc}
      */
-    public function readline(string $prompt = null)
+    public function readline(?string $prompt = null)
     {
         return \readline($prompt);
     }

--- a/src/Readline/Hoa/AutocompleterPath.php
+++ b/src/Readline/Hoa/AutocompleterPath.php
@@ -62,8 +62,8 @@ class AutocompleterPath implements Autocompleter
      * Constructor.
      */
     public function __construct(
-        string $root = null,
-        \Closure $iteratorFactory = null
+        ?string $root = null,
+        ?\Closure $iteratorFactory = null
     ) {
         if (null === $root) {
             $root = static::PWD;

--- a/src/Readline/Hoa/ConsoleCursor.php
+++ b/src/Readline/Hoa/ConsoleCursor.php
@@ -154,7 +154,7 @@ class ConsoleCursor
      * Move to the line X and the column Y.
      * If null, use the current coordinate.
      */
-    public static function moveTo(int $x = null, int $y = null)
+    public static function moveTo(?int $x = null, ?int $y = null)
     {
         if (null === $x || null === $y) {
             $position = static::getPosition();

--- a/src/Readline/Hoa/ConsoleInput.php
+++ b/src/Readline/Hoa/ConsoleInput.php
@@ -53,7 +53,7 @@ class ConsoleInput implements StreamIn
     /**
      * Wraps an `Hoa\Stream\IStream\In` stream.
      */
-    public function __construct(StreamIn $input = null)
+    public function __construct(?StreamIn $input = null)
     {
         if (null === $input) {
             if (\defined('STDIN') &&

--- a/src/Readline/Hoa/ConsoleOutput.php
+++ b/src/Readline/Hoa/ConsoleOutput.php
@@ -57,7 +57,7 @@ class ConsoleOutput implements StreamOut
     /**
      * Wraps an `Hoa\Stream\IStream\Out` stream.
      */
-    public function __construct(StreamOut $output = null)
+    public function __construct(?StreamOut $output = null)
     {
         $this->_output = $output;
 

--- a/src/Readline/Hoa/ConsoleProcessus.php
+++ b/src/Readline/Hoa/ConsoleProcessus.php
@@ -245,10 +245,10 @@ class ConsoleProcessus extends Stream implements StreamIn, StreamOut, StreamPath
      */
     public function __construct(
         string $command,
-        array $options = null,
-        array $descriptors = null,
-        string $cwd = null,
-        array $environment = null,
+        ?array $options = null,
+        ?array $descriptors = null,
+        ?string $cwd = null,
+        ?array $environment = null,
         int $timeout = 30
     ) {
         $this->setCommand($command);
@@ -285,7 +285,7 @@ class ConsoleProcessus extends Stream implements StreamIn, StreamOut, StreamPath
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         $out = @\proc_open(
             $streamName,
@@ -527,7 +527,7 @@ class ConsoleProcessus extends Stream implements StreamIn, StreamOut, StreamPath
      * Read an array.
      * Alias of the $this->scanf() method.
      */
-    public function readArray(string $format = null, int $pipe = 1)
+    public function readArray(?string $format = null, int $pipe = 1)
     {
         return $this->scanf($format, $pipe);
     }

--- a/src/Readline/Hoa/Exception.php
+++ b/src/Readline/Hoa/Exception.php
@@ -52,7 +52,7 @@ class Exception extends ExceptionIdle implements EventSource
         string $message,
         int $code = 0,
         $arguments = [],
-        \Throwable $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $code, $arguments, $previous);
 

--- a/src/Readline/Hoa/ExceptionIdle.php
+++ b/src/Readline/Hoa/ExceptionIdle.php
@@ -79,7 +79,7 @@ class ExceptionIdle extends \Exception
         string $message,
         int $code = 0,
         $arguments = [],
-        \Exception $previous = null
+        ?\Exception $previous = null
     ) {
         $this->_tmpArguments = $arguments;
         parent::__construct($message, $code, $previous);

--- a/src/Readline/Hoa/File.php
+++ b/src/Readline/Hoa/File.php
@@ -105,7 +105,7 @@ abstract class File extends FileGeneric implements StreamBufferable, StreamLocka
     public function __construct(
         string $streamName,
         string $mode,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         $this->setMode($mode);
@@ -140,7 +140,7 @@ abstract class File extends FileGeneric implements StreamBufferable, StreamLocka
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         if (\substr($streamName, 0, 4) === 'file' &&
             false === \is_dir(\dirname($streamName))) {
@@ -181,7 +181,7 @@ abstract class File extends FileGeneric implements StreamBufferable, StreamLocka
      * Start a new buffer.
      * The callable acts like a light filter.
      */
-    public function newBuffer($callable = null, int $size = null): int
+    public function newBuffer($callable = null, ?int $size = null): int
     {
         $this->setStreamBuffer($size);
 

--- a/src/Readline/Hoa/FileDirectory.php
+++ b/src/Readline/Hoa/FileDirectory.php
@@ -66,7 +66,7 @@ class FileDirectory extends FileGeneric
     public function __construct(
         string $streamName,
         string $mode = self::MODE_READ,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         $this->setMode($mode);
@@ -78,7 +78,7 @@ class FileDirectory extends FileGeneric
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         if (false === \is_dir($streamName)) {
             if ($this->getMode() === self::MODE_READ) {
@@ -185,7 +185,7 @@ class FileDirectory extends FileGeneric
     public static function create(
         string $name,
         string $mode = self::MODE_CREATE_RECURSIVE,
-        string $context = null
+        ?string $context = null
     ): bool {
         if (true === \is_dir($name)) {
             return true;

--- a/src/Readline/Hoa/FileGeneric.php
+++ b/src/Readline/Hoa/FileGeneric.php
@@ -229,7 +229,7 @@ abstract class FileGeneric extends Stream implements StreamPathable, StreamStata
     /**
      * Set access and modification time of file.
      */
-    public function touch(int $time = null, int $atime = null): bool
+    public function touch(?int $time = null, ?int $atime = null): bool
     {
         if (null === $time) {
             $time = \time();
@@ -333,7 +333,7 @@ abstract class FileGeneric extends Stream implements StreamPathable, StreamStata
     /**
      * Change the current umask.
      */
-    public static function umask(int $umask = null): int
+    public static function umask(?int $umask = null): int
     {
         if (null === $umask) {
             return \umask();

--- a/src/Readline/Hoa/FileLink.php
+++ b/src/Readline/Hoa/FileLink.php
@@ -49,7 +49,7 @@ class FileLink extends File
     public function __construct(
         string $streamName,
         string $mode,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         if (!\is_link($streamName)) {

--- a/src/Readline/Hoa/FileLinkRead.php
+++ b/src/Readline/Hoa/FileLinkRead.php
@@ -57,7 +57,7 @@ class FileLinkRead extends FileLink implements StreamIn
     public function __construct(
         string $streamName,
         string $mode = parent::MODE_READ,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         parent::__construct($streamName, $mode, $context, $wait);
@@ -76,7 +76,7 @@ class FileLinkRead extends FileLink implements StreamIn
      * @throws \Hoa\File\Exception\FileDoesNotExist
      * @throws \Hoa\File\Exception
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         static $createModes = [
             parent::MODE_READ,
@@ -190,7 +190,7 @@ class FileLinkRead extends FileLink implements StreamIn
      *
      * @return array
      */
-    public function readArray(string $format = null)
+    public function readArray(?string $format = null)
     {
         return $this->scanf($format);
     }

--- a/src/Readline/Hoa/FileLinkReadWrite.php
+++ b/src/Readline/Hoa/FileLinkReadWrite.php
@@ -49,7 +49,7 @@ class FileLinkReadWrite extends FileLink implements StreamIn, StreamOut
     public function __construct(
         string $streamName,
         string $mode = parent::MODE_APPEND_READ_WRITE,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         parent::__construct($streamName, $mode, $context, $wait);
@@ -60,7 +60,7 @@ class FileLinkReadWrite extends FileLink implements StreamIn, StreamOut
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         static $createModes = [
             parent::MODE_READ_WRITE,
@@ -150,7 +150,7 @@ class FileLinkReadWrite extends FileLink implements StreamIn, StreamOut
      * Read an array.
      * Alias of the $this->scanf() method.
      */
-    public function readArray(string $format = null)
+    public function readArray(?string $format = null)
     {
         return $this->scanf($format);
     }

--- a/src/Readline/Hoa/FileRead.php
+++ b/src/Readline/Hoa/FileRead.php
@@ -49,7 +49,7 @@ class FileRead extends File implements StreamIn
     public function __construct(
         string $streamName,
         string $mode = parent::MODE_READ,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         parent::__construct($streamName, $mode, $context, $wait);
@@ -60,7 +60,7 @@ class FileRead extends File implements StreamIn
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         static $createModes = [
             parent::MODE_READ,
@@ -146,7 +146,7 @@ class FileRead extends File implements StreamIn
      * Read an array.
      * Alias of the $this->scanf() method.
      */
-    public function readArray(string $format = null)
+    public function readArray(?string $format = null)
     {
         return $this->scanf($format);
     }

--- a/src/Readline/Hoa/FileReadWrite.php
+++ b/src/Readline/Hoa/FileReadWrite.php
@@ -49,7 +49,7 @@ class FileReadWrite extends File implements StreamIn, StreamOut
     public function __construct(
         string $streamName,
         string $mode = parent::MODE_APPEND_READ_WRITE,
-        string $context = null,
+        ?string $context = null,
         bool $wait = false
     ) {
         parent::__construct($streamName, $mode, $context, $wait);
@@ -60,7 +60,7 @@ class FileReadWrite extends File implements StreamIn, StreamOut
     /**
      * Open the stream and return the associated resource.
      */
-    protected function &_open(string $streamName, StreamContext $context = null)
+    protected function &_open(string $streamName, ?StreamContext $context = null)
     {
         static $createModes = [
             parent::MODE_READ_WRITE,
@@ -150,7 +150,7 @@ class FileReadWrite extends File implements StreamIn, StreamOut
      * Read an array.
      * Alias of the $this->scanf() method.
      */
-    public function readArray(string $format = null)
+    public function readArray(?string $format = null)
     {
         return $this->scanf($format);
     }

--- a/src/Readline/Hoa/IteratorFileSystem.php
+++ b/src/Readline/Hoa/IteratorFileSystem.php
@@ -53,7 +53,7 @@ class IteratorFileSystem extends \FilesystemIterator
      * Please, see \FileSystemIterator::__construct() method.
      * We add the $splFileInfoClass parameter.
      */
-    public function __construct(string $path, int $flags = null, string $splFileInfoClass = null)
+    public function __construct(string $path, ?int $flags = null, ?string $splFileInfoClass = null)
     {
         $this->_splFileInfoClass = $splFileInfoClass;
 

--- a/src/Readline/Hoa/IteratorRecursiveDirectory.php
+++ b/src/Readline/Hoa/IteratorRecursiveDirectory.php
@@ -58,7 +58,7 @@ class IteratorRecursiveDirectory extends \RecursiveDirectoryIterator
      * Please, see \RecursiveDirectoryIterator::__construct() method.
      * We add the $splFileInfoClass parameter.
      */
-    public function __construct(string $path, int $flags = null, string $splFileInfoClass = null)
+    public function __construct(string $path, ?int $flags = null, ?string $splFileInfoClass = null)
     {
         if (null === $flags) {
             parent::__construct($path);

--- a/src/Readline/Hoa/IteratorSplFileInfo.php
+++ b/src/Readline/Hoa/IteratorSplFileInfo.php
@@ -56,7 +56,7 @@ class IteratorSplFileInfo extends \SplFileInfo
     /**
      * Construct.
      */
-    public function __construct(string $filename, string $relativePath = null)
+    public function __construct(string $filename, ?string $relativePath = null)
     {
         parent::__construct($filename);
 

--- a/src/Readline/Hoa/ProtocolNode.php
+++ b/src/Readline/Hoa/ProtocolNode.php
@@ -62,7 +62,7 @@ class ProtocolNode implements \ArrayAccess, \IteratorAggregate
      * overload the `$_name` attribute), we can set the `$_name` attribute
      * dynamically. This is useful to create a node on-the-fly.
      */
-    public function __construct(string $name = null, string $reach = null, array $children = [])
+    public function __construct(?string $name = null, ?string $reach = null, array $children = [])
     {
         if (null !== $name) {
             $this->_name = $name;
@@ -133,7 +133,7 @@ class ProtocolNode implements \ArrayAccess, \IteratorAggregate
      * Resolve a path, i.e. iterate the nodes tree and reach the queue of
      * the path.
      */
-    protected function _resolve(string $path, &$accumulator, string $id = null)
+    protected function _resolve(string $path, &$accumulator, ?string $id = null)
     {
         if (\substr($path, 0, 6) === 'hoa://') {
             $path = \substr($path, 6);
@@ -246,7 +246,7 @@ class ProtocolNode implements \ArrayAccess, \IteratorAggregate
      * Queue of the node.
      * Generic one. Must be overrided in children classes.
      */
-    public function reach(string $queue = null)
+    public function reach(?string $queue = null)
     {
         return empty($queue) ? $this->_reach : $queue;
     }

--- a/src/Readline/Hoa/ProtocolNodeLibrary.php
+++ b/src/Readline/Hoa/ProtocolNodeLibrary.php
@@ -44,7 +44,7 @@ class ProtocolNodeLibrary extends ProtocolNode
     /**
      * Queue of the component.
      */
-    public function reach(string $queue = null)
+    public function reach(?string $queue = null)
     {
         $withComposer = \class_exists('Composer\Autoload\ClassLoader', false) ||
             ('cli' === \PHP_SAPI && \file_exists(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'autoload.php'));

--- a/src/Readline/Hoa/Readline.php
+++ b/src/Readline/Hoa/Readline.php
@@ -137,7 +137,7 @@ class Readline
     /**
      * Read a line from the input.
      */
-    public function readLine(string $prefix = null)
+    public function readLine(?string $prefix = null)
     {
         $input = Console::getInput();
 
@@ -270,7 +270,7 @@ class Readline
     /**
      * Add an entry in the history.
      */
-    public function addHistory(string $line = null)
+    public function addHistory(?string $line = null)
     {
         if (empty($line)) {
             return;
@@ -294,7 +294,7 @@ class Readline
     /**
      * Get an entry in the history.
      */
-    public function getHistory(int $i = null)
+    public function getHistory(?int $i = null)
     {
         if (null === $i) {
             $i = $this->_historyCurrent;

--- a/src/Readline/Hoa/Stream.php
+++ b/src/Readline/Hoa/Stream.php
@@ -110,7 +110,7 @@ abstract class Stream implements IStream, EventListenable
      * If not exists in the register, try to call the
      * `$this->_open()` method. Please, see the `self::_getStream()` method.
      */
-    public function __construct(string $streamName, string $context = null, bool $wait = false)
+    public function __construct(string $streamName, ?string $context = null, bool $wait = false)
     {
         $this->_streamName = $streamName;
         $this->_context = $context;
@@ -150,7 +150,7 @@ abstract class Stream implements IStream, EventListenable
     private static function &_getStream(
         string $streamName,
         self $handler,
-        string $context = null
+        ?string $context = null
     ): array {
         $name = \md5($streamName);
 
@@ -195,7 +195,7 @@ abstract class Stream implements IStream, EventListenable
      * Note: This method is protected, but do not forget that it could be
      * overloaded into a public context.
      */
-    abstract protected function &_open(string $streamName, StreamContext $context = null);
+    abstract protected function &_open(string $streamName, ?StreamContext $context = null);
 
     /**
      * Close the current stream.

--- a/src/Readline/Hoa/StreamBufferable.php
+++ b/src/Readline/Hoa/StreamBufferable.php
@@ -49,7 +49,7 @@ interface StreamBufferable extends IStream
      * Start a new buffer.
      * The callable acts like a light filter.
      */
-    public function newBuffer($callable = null, int $size = null): int;
+    public function newBuffer($callable = null, ?int $size = null): int;
 
     /**
      * Flush the buffer.

--- a/src/Readline/Hoa/StreamTouchable.php
+++ b/src/Readline/Hoa/StreamTouchable.php
@@ -106,5 +106,5 @@ interface StreamTouchable extends IStream
     /**
      * Change the current umask.
      */
-    public static function umask(int $umask = null): int;
+    public static function umask(?int $umask = null): int;
 }

--- a/src/Readline/Readline.php
+++ b/src/Readline/Readline.php
@@ -70,7 +70,7 @@ interface Readline
      *
      * @return false|string
      */
-    public function readline(string $prompt = null);
+    public function readline(?string $prompt = null);
 
     /**
      * Redraw readline to redraw the display.

--- a/src/Readline/Transient.php
+++ b/src/Readline/Transient.php
@@ -110,7 +110,7 @@ class Transient implements Readline
      *
      * @return false|string
      */
-    public function readline(string $prompt = null)
+    public function readline(?string $prompt = null)
     {
         echo $prompt;
 

--- a/src/Readline/Userland.php
+++ b/src/Readline/Userland.php
@@ -138,7 +138,7 @@ class Userland implements Readline
      *
      * @return string
      */
-    public function readline(string $prompt = null)
+    public function readline(?string $prompt = null)
     {
         $this->lastPrompt = $prompt;
 

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -79,7 +79,7 @@ class Shell extends Application
      *
      * @param Configuration|null $config (default: null)
      */
-    public function __construct(Configuration $config = null)
+    public function __construct(?Configuration $config = null)
     {
         $this->config = $config ?: new Configuration();
         $this->cleaner = $this->config->getCodeCleaner();
@@ -313,7 +313,7 @@ class Shell extends Application
      *
      * @return int 0 if everything went fine, or an error code
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         // We'll just ignore the input passed in, and set up our own!
         $input = new ArrayInput([]);

--- a/src/Util/Mirror.php
+++ b/src/Util/Mirror.php
@@ -42,7 +42,7 @@ class Mirror
      *
      * @return \Reflector
      */
-    public static function get($value, string $member = null, int $filter = 15): \Reflector
+    public static function get($value, ?string $member = null, int $filter = 15): \Reflector
     {
         if ($member === null && \is_string($value)) {
             if (\function_exists($value)) {

--- a/src/VarDumper/Presenter.php
+++ b/src/VarDumper/Presenter.php
@@ -105,7 +105,7 @@ class Presenter
      * @param int   $depth   (default: null)
      * @param int   $options One of Presenter constants
      */
-    public function present($value, int $depth = null, int $options = 0): string
+    public function present($value, ?int $depth = null, int $options = 0): string
     {
         $data = $this->cloner->cloneVar($value, !($options & self::VERBOSE) ? Caster::EXCLUDE_VERBOSE : 0);
 

--- a/src/VersionUpdater/Installer.php
+++ b/src/VersionUpdater/Installer.php
@@ -25,7 +25,7 @@ class Installer
      */
     protected $tempDirectory;
 
-    public function __construct(string $tempDirectory = null)
+    public function __construct(?string $tempDirectory = null)
     {
         $this->tempDirectory = $tempDirectory ?: \sys_get_temp_dir();
         $this->installLocation = \Phar::running(false);

--- a/src/functions.php
+++ b/src/functions.php
@@ -128,7 +128,7 @@ if (!\function_exists('Psy\\info')) {
      *
      * @return array|null
      */
-    function info(Configuration $config = null)
+    function info(?Configuration $config = null)
     {
         static $lastConfig;
         if ($config !== null) {

--- a/test/FakeShell.php
+++ b/test/FakeShell.php
@@ -18,7 +18,7 @@ class FakeShell extends Shell
 {
     public $matchers;
 
-    public function __construct(Configuration $config = null)
+    public function __construct(?Configuration $config = null)
     {
         // Do something (silly) with $config for phpstan's sake.
         $config = null;

--- a/test/Formatter/SignatureFormatterTest.php
+++ b/test/Formatter/SignatureFormatterTest.php
@@ -24,7 +24,7 @@ class SignatureFormatterTest extends \Psy\Test\TestCase
     const FOO = 'foo value';
     private static $bar = 'bar value';
 
-    private function someFakeMethod(array $one, $two = 'TWO', \Reflector $three = null)
+    private function someFakeMethod(array $one, $two = 'TWO', ?\Reflector $three = null)
     {
     }
 

--- a/test/VersionUpdater/SelfUpdateTest.php
+++ b/test/VersionUpdater/SelfUpdateTest.php
@@ -250,7 +250,7 @@ class SelfUpdateTest extends \Psy\Test\TestCase
         return $downloader;
     }
 
-    private function getMockOutput(string $expectOutput = null)
+    private function getMockOutput(?string $expectOutput = null)
     {
         $methods = \get_class_methods(OutputInterface::class);
         $builder = $this->getMockBuilder(OutputInterface::class);


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)