### PR TITLE
Confirm `less` is link before using it as such

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1263,7 +1263,7 @@ class Configuration
                 // let's not use it by default.
                 //
                 // See https://github.com/bobthecow/psysh/issues/778
-                $link = @\readlink($less);
+                $link = @\is_link($less) ? @\readlink($less) : $less;
                 if ($link !== false && \strpos($link, 'busybox') !== false) {
                     return false;
                 }


### PR DESCRIPTION
The PHP [docs](https://www.php.net/manual/en/function.readlink.php) of `readlink()` indicate that if the path provided is not a link, it fails.

> Note: The function fails if path is not a symlink, except on Windows, where the normalized path will be returned.

I am seeing this in Docker with PHP FPM image, with Alpine 3.20.3, PHP 8.2.23:

```
65aefc8b7840:/var/www/html$ php artisan tinker

   ErrorException 

  readlink(): Invalid argument

  at vendor/psy/psysh/src/Configuration.php:1266
    1262▕                 // n.b. The busybox less implementation is a bit broken, so
    1263▕                 // let's not use it by default.
    1264▕                 //
    1265▕                 // See https://github.com/bobthecow/psysh/issues/778
  ➜ 1266▕                 $link = @\readlink($less);
    1267▕                 if ($link !== false && \strpos($link, 'busybox') !== false) {
    1268▕                     return false;
    1269▕                 }
    1270▕ 

      +16 vendor frames 
  17  artisan:31
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```