### PR TITLE
Improve PassableByReference variadic placeholder param support.

### DIFF
--- a/src/CodeCleaner/PassableByReferencePass.php
+++ b/src/CodeCleaner/PassableByReferencePass.php
@@ -21,6 +21,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\VariadicPlaceholder;
 use Psy\Exception\FatalErrorException;
 
 /**
@@ -61,6 +62,10 @@ class PassableByReferencePass extends CodeCleanerPass
 
             $args = [];
             foreach ($node->args as $position => $arg) {
+                if ($node instanceof VariadicPlaceholder) {
+                    continue;
+                }
+
                 $args[$arg->name !== null ? $arg->name->name : $position] = $arg;
             }
 

--- a/test/CodeCleaner/PassableByReferencePassTest.php
+++ b/test/CodeCleaner/PassableByReferencePassTest.php
@@ -77,6 +77,10 @@ class PassableByReferencePassTest extends CodeCleanerTestCase
             $values[] = ['preg_match(\'/\d+/\', \'123456\', offset: 2)'];
         }
 
+        if (\version_compare(\PHP_VERSION, '8.1', '>=')) {
+            $values[] = ['intval(...)'];
+        }
+
         return $values;
     }
 


### PR DESCRIPTION
Similar to #695, this PR fixes a warning with the following code:

```php
array_map(intval(...), ['1', '2']);

// Warning: Undefined property: PhpParser\Node\VariadicPlaceholder::$name.
```
