### PR TITLE
Default to false removeDuplicates when instantiating Readline

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -819,7 +819,7 @@ class Configuration
             $this->readline = new $className(
                 $this->getHistoryFile(),
                 $this->getHistorySize(),
-                $this->getEraseDuplicates()
+                $this->getEraseDuplicates() ?? false
             );
         }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -713,7 +713,7 @@ class Configuration
      */
     public function setEraseDuplicates(bool $value)
     {
-        $this->eraseDuplicates = (bool) $value;
+        $this->eraseDuplicates = $value;
     }
 
     /**

--- a/src/Readline/Transient.php
+++ b/src/Readline/Transient.php
@@ -50,7 +50,7 @@ class Transient implements Readline
         // don't do anything with the history file...
         $this->history = [];
         $this->historySize = $historySize;
-        $this->eraseDups = $eraseDups;
+        $this->eraseDups = $eraseDups ?? false;
     }
 
     /**


### PR DESCRIPTION
## Description

A user experienced this error when using [Laravel Tinker](https://github.com/laravel/tinker):

>   Cannot assign null to property Psy\Readline\Transient::$eraseDups of type bool
>   at vendor/psy/psysh/src/Readline/Transient.php:53

## Cause of bug

The error is caused by line 53 of Transient.php, where the constructor sets the value of $eraseDups.

The constructor has this signature:

```php
public function __construct($historyFile = null, $historySize = 0, $eraseDups = false)
```

Types are not declared(See notes at bottom). When this constructor is used with the parameters explicitly being null, it will overwrite defaults in PHP8.0 and greater.

In the constructor body, it sets the value of the eraseDups variable.

```php
private bool $eraseDups; // Variable declared at the top of the class

$this->eraseDups = $eraseDups; // Inside the constructor body
```

This can result in the constructor trying to assign null to the $eraseDups variable. This causes an error as the variable is not declared nullable.

## Changes made

### Configuration.php

Pass the default value of false when instantiating the ReadLine class in the getReadLine function.

```php 
 public function getReadline(): Readline\Readline
    {
        if (!isset($this->readline)) {
            $className = $this->getReadlineClass();
            $this->readline = new $className(
                $this->getHistoryFile(),
                $this->getHistorySize(),
                $this->getEraseDuplicates() ?? false // Added ternary operator to use false if null
            );
        }

        return $this->readline;
    }
```

The setEraseDuplicates function type casting was removed. It wasn't related to this bug, but the function signature declares the type as bool, making the cast redundant.

```php
$this->eraseDuplicates = (bool) $value; // old
$this->eraseDuplicates = $value; // new

### Transient.php

The constructor now sets the value of eraseDups to false if the parameter is null.

```php 
$this->eraseDups = $eraseDups ?? false;
```

The constructor also sets a default history size where the parameter is null.

```php
$this->historySize = $historySize ?? 0;
```

Updated function signature with types

```php 
public function __construct($historyFile = null, ?int $historySize = 0, ?bool $eraseDups = false)
```

### Readline.php (Interface)

Updated constructor signature with more accurate type declarations.

```php
 public function __construct($historyFile = null, ?int $historySize = 0, ?bool $eraseDups = false);
```

