### PR TITLE
Avoid matching functions against ->

### DIFF
--- a/src/TabCompletion/Matcher/FunctionsMatcher.php
+++ b/src/TabCompletion/Matcher/FunctionsMatcher.php
@@ -44,7 +44,7 @@ class FunctionsMatcher extends AbstractMatcher
         $prevToken = \array_pop($tokens);
 
         switch (true) {
-            case self::tokenIs($prevToken, self::T_NEW):
+            case self::hasToken([self::T_NEW, self::T_OBJECT_OPERATOR], $prevToken):
                 return false;
             case self::hasToken([self::T_OPEN_TAG, self::T_STRING], $token):
             case self::isOperator($token):


### PR DESCRIPTION
I'm sorry if my train of thought is a bit limited, but it doesn't make sense to call a function after `->«any_partial_string»`.... does it? 👀