### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/Command/ListCommand/PropertyEnumerator.php
+++ b/src/Command/ListCommand/PropertyEnumerator.php
@@ -168,7 +168,9 @@ class PropertyEnumerator extends Enumerator
             return '';
         }
 
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $value = $property->getValue($target);
 
         return $this->presentRef($value);

--- a/src/Sudo.php
+++ b/src/Sudo.php
@@ -62,7 +62,9 @@ class Sudo
     {
         $refl = new \ReflectionObject($object);
         $reflMethod = $refl->getMethod($method);
-        $reflMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflMethod->setAccessible(true);
+        }
 
         return $reflMethod->invokeArgs($object, $args);
     }
@@ -78,7 +80,9 @@ class Sudo
     public static function fetchStaticProperty($class, string $property)
     {
         $prop = self::getProperty(new \ReflectionClass($class), $property);
-        $prop->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $prop->setAccessible(true);
+        }
 
         return $prop->getValue();
     }
@@ -119,7 +123,9 @@ class Sudo
     {
         $refl = new \ReflectionClass($class);
         $reflMethod = $refl->getMethod($method);
-        $reflMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflMethod->setAccessible(true);
+        }
 
         return $reflMethod->invokeArgs(null, $args);
     }
@@ -164,7 +170,9 @@ class Sudo
         $instance = $refl->newInstanceWithoutConstructor();
 
         $constructor = $refl->getConstructor();
-        $constructor->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $constructor->setAccessible(true);
+        }
         $constructor->invokeArgs($instance, $args);
 
         return $instance;
@@ -186,7 +194,9 @@ class Sudo
         do {
             try {
                 $prop = $refl->getProperty($property);
-                $prop->setAccessible(true);
+                if (\PHP_VERSION_ID < 80100) {
+                    $prop->setAccessible(true);
+                }
 
                 return $prop;
             } catch (\ReflectionException $e) {

--- a/test/Input/ShellInputTest.php
+++ b/test/Input/ShellInputTest.php
@@ -101,7 +101,9 @@ class ShellInputTest extends \Psy\Test\TestCase
         $input = new ShellInput($input);
         $r = new \ReflectionClass(ShellInput::class);
         $p = $r->getProperty('tokenPairs');
-        $p->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
         $this->assertSame($tokens, $p->getValue($input), $message);
     }
 

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -629,7 +629,9 @@ class ShellTest extends TestCase
         // :-/
         $refl = new \ReflectionClass(Shell::class);
         $method = $refl->getMethod('hasCommand');
-        $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $this->assertSame($method->invokeArgs($shell, [$command]), $has);
     }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations