### PR TITLE
[PHP 8.5] Fix `\Psy\Shell::writeStdout` to return an empty string

### DIFF
--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1098,8 +1098,10 @@ class Shell extends Application
      *
      * @param string $out
      * @param int    $phase Output buffering phase
+     *
+     * @return string Empty string
      */
-    public function writeStdout(string $out, int $phase = \PHP_OUTPUT_HANDLER_END)
+    public function writeStdout(string $out, int $phase = \PHP_OUTPUT_HANDLER_END): string
     {
         if ($phase & \PHP_OUTPUT_HANDLER_START) {
             if ($this->output instanceof ShellOutput) {
@@ -1138,6 +1140,8 @@ class Shell extends Application
                 $this->output->stopPaging();
             }
         }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
PHP 8.5 implements a PHP 8.4 deprecation, that `ob_start` output handler (`\Psy\Shell::writeStdout` in our case) should return a string.

Returning a non-string now emits a deprecation notice:

```output
Deprecated: ob_end_flush(): Returning a non-string result from user output handler Psy\Shell::writeStdout is deprecated in src/ExecutionLoopClosure.php on line 66
```

php-src commit[^1] | RFC[^2] | PHP.Watch[^3]

[^1]: https://github.com/php/php-src/pull/18932/files
[^2]: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_returning_non-string_values_from_a_user_output_handler
[^3]: https://php.watch/versions/8.5/ob_handler-return-non-string