### PR TITLE
feat: create configuration option to enable/disable the consise retur…

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -41,19 +41,19 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Configuration
 {
-    const COLOR_MODE_AUTO = 'auto';
-    const COLOR_MODE_FORCED = 'forced';
-    const COLOR_MODE_DISABLED = 'disabled';
+    public const COLOR_MODE_AUTO = 'auto';
+    public const COLOR_MODE_FORCED = 'forced';
+    public const COLOR_MODE_DISABLED = 'disabled';
 
-    const INTERACTIVE_MODE_AUTO = 'auto';
-    const INTERACTIVE_MODE_FORCED = 'forced';
-    const INTERACTIVE_MODE_DISABLED = 'disabled';
+    public const INTERACTIVE_MODE_AUTO = 'auto';
+    public const INTERACTIVE_MODE_FORCED = 'forced';
+    public const INTERACTIVE_MODE_DISABLED = 'disabled';
 
-    const VERBOSITY_QUIET = 'quiet';
-    const VERBOSITY_NORMAL = 'normal';
-    const VERBOSITY_VERBOSE = 'verbose';
-    const VERBOSITY_VERY_VERBOSE = 'very_verbose';
-    const VERBOSITY_DEBUG = 'debug';
+    public const VERBOSITY_QUIET = 'quiet';
+    public const VERBOSITY_NORMAL = 'normal';
+    public const VERBOSITY_VERBOSE = 'verbose';
+    public const VERBOSITY_VERY_VERBOSE = 'very_verbose';
+    public const VERBOSITY_DEBUG = 'debug';
 
     private const AVAILABLE_OPTIONS = [
         'codeCleaner',
@@ -82,6 +82,7 @@ class Configuration
         'updateCheck',
         'updateManualCheck',
         'useBracketedPaste',
+        'useConciseReturnValue',
         'usePcntl',
         'useReadline',
         'useTabCompletion',
@@ -132,6 +133,7 @@ class Configuration
     private string $verbosity = self::VERBOSITY_NORMAL;
     private bool $yolo = false;
     private ?Theme $theme = null;
+    private ?bool $useConciseReturnValue = true;
 
     // services
     private ?Readline\Readline $readline = null;
@@ -2541,5 +2543,32 @@ class Configuration
         $mode = $stat['mode'] & 0170000;
 
         return $mode === 0010000 || $mode === 0040000 || $mode === 0100000 || $mode === 0120000;
+    }
+
+    /**
+     * Enable or disable concise return values for actions.
+     *
+     * When enabled (default), PsySH will show abbreviated output for commands
+     * that appear to be "actions" (assignments, method calls that modify state)
+     * and more detailed output for "inspections" (variable reads, getters, etc.).
+     *
+     * When disabled, all return values are shown with full detail regardless
+     * of the command type.
+     *
+     * @param bool $useConciseReturnValue
+     */
+    public function setUseConciseReturnValue(bool $useConciseReturnValue): void
+    {
+        $this->useConciseReturnValue = (bool) $useConciseReturnValue;
+    }
+
+    /**
+     * Check whether to use concise return values for actions.
+     *
+     * @return bool True if concise return values should be used (default: true)
+     */
+    public function useConciseReturnValue(): bool
+    {
+        return $this->useConciseReturnValue ?? true;
     }
 }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1284,8 +1284,9 @@ class Shell extends Application
         } else {
             $prompt = $this->config->theme()->returnValue();
             $indent = \str_repeat(' ', \strlen($prompt));
-            // Use concise output for actions, full output for inspection
-            $formatted = $this->presentValue($ret, $this->codeLooksLikeAction);
+            // Use concise output for actions if the config option is enabled
+            $useConcise = $this->config->useConciseReturnValue() && $this->codeLooksLikeAction;
+            $formatted = $this->presentValue($ret, $useConcise);
             $formattedRetValue = \sprintf('<whisper>%s</whisper>', $prompt);
 
             $formatted = $formattedRetValue.\str_replace(\PHP_EOL, \PHP_EOL.$indent, $formatted);

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -752,4 +752,41 @@ class ConfigurationTest extends TestCase
         ]);
         $config->getAutoloadWarmers();
     }
+
+    public function testUseConciseReturnValueDefault()
+    {
+        $config = $this->getConfig();
+
+        // Default should be true (enabled)
+        $this->assertTrue($config->useConciseReturnValue());
+    }
+
+    public function testUseConciseReturnValueEnabled()
+    {
+        $config = $this->getConfig();
+        $config->setUseConciseReturnValue(true);
+
+        $this->assertTrue($config->useConciseReturnValue());
+    }
+
+    public function testUseConciseReturnValueDisabled()
+    {
+        $config = $this->getConfig();
+        $config->setUseConciseReturnValue(false);
+
+        $this->assertFalse($config->useConciseReturnValue());
+    }
+
+    public function testUseConciseReturnValueViaLoadConfig()
+    {
+        $config = $this->getConfig();
+
+        // Test enabling via loadConfig
+        $config->loadConfig(['useConciseReturnValue' => true]);
+        $this->assertTrue($config->useConciseReturnValue());
+
+        // Test disabling via loadConfig
+        $config->loadConfig(['useConciseReturnValue' => false]);
+        $this->assertFalse($config->useConciseReturnValue());
+    }
 }


### PR DESCRIPTION
# Concise Return Value Configuration

## Overview

Both I and other users (mainly Laravel users) experienced discomfort with the change made in commit 932daa0, linked to issues #512 and #888.

So, instead of just complaining and debating, I created an option for each user to choose how they want the default output to be. However, the concise mode, as implemented in the aforementioned commit, remains the default.

With this changes, PsySH now includes a configurable option to control whether return values are displayed in a concise format for "action" commands (like assignments and setters) versus "inspection" commands (like variable reads and getters).

## Configuration Option

- **Option name**: `useConciseReturnValue`
- **Type**: `boolean`
- **Default**: `true` (enabled)

## Behavior

When **enabled** (default):
- Action commands (assignments, setters, etc.) show abbreviated output
- Inspection commands (variable reads, getters, etc.) show full detailed output

When **disabled**:
- All commands show full detailed output regardless of type
## How to Configure

### Option 1: Via Configuration File

Create or edit your PsySH configuration file (usually `~/.config/psysh/config.php`):

```php
<?php

return [
    // Always show full output for all commands
    'useConciseReturnValue' => false,

    // OR: Enable concise output for actions (default behavior)
    // 'useConciseReturnValue' => true,
];
```

### Option 2: Programmatically

```php
<?php

use Psy\Configuration;
use Psy\Shell;

$config = new Configuration([
    'useConciseReturnValue' => false, // Show full output always
]);

$shell = new Shell($config);
$shell->run();
```

### Option 3: At Runtime

```php
$config = new Configuration();
$config->setUseConciseReturnValue(false); // Disable concise output
```

