### PR TITLE
Don't call curl_close() on PHP >= 8.0.0

### DIFF
--- a/src/VersionUpdater/Downloader/CurlDownloader.php
+++ b/src/VersionUpdater/Downloader/CurlDownloader.php
@@ -58,7 +58,9 @@ class CurlDownloader implements Downloader
         \curl_setopt($curl, \CURLOPT_URL, $url);
         $result = \curl_exec($curl);
         $error = \curl_error($curl);
-        \curl_close($curl);
+        if (\PHP_VERSION_ID < 80000) {
+            \curl_close($curl);
+        }
 
         \fclose($outputHandle);
 


### PR DESCRIPTION
`curl_close()` is noop since 8.0.0 and emits `E_DEPRECATED` since 8.5.0.

This changes the code to call `curl_close()` only on PHP < 8.0.0.

* https://www.php.net/curl_close
* https://github.com/php/php-src/blob/php-8.0.0/UPGRADING#L1016-L1020
* https://github.com/php/php-src/blob/php-8.5.0/UPGRADING#L416-L418