### PR TITLE
Fix error message formatting matching too many characters

### DIFF
--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1977,7 +1977,7 @@ class Shell extends Application
 
         $message = \preg_replace(
             [
-                "#(?:[A-Za-z]:)?[\\\\/][^\\r\\n]*?[\\\\/]src[\\\\/]Execution(?:Loop)?Closure\\.php\\(\\d+\\) : eval\\(\\)'d code#",
+                "#(?:[A-Za-z]:)?[\\\\/][^\\s]*?[\\\\/]src[\\\\/]Execution(?:Loop)?Closure\\.php\\(\\d+\\) : eval\\(\\)'d code#",
                 "#\\bsrc[\\\\/]Execution(?:Loop)?Closure\\.php\\(\\d+\\) : eval\\(\\)'d code#",
             ],
             "eval()'d code",


### PR DESCRIPTION
Closes #943 

Matches until the first non whitespaces character to extract the  `psysh/src` path of the error message