### PR TITLE
Make include loading exception-safe

### DIFF
--- a/src/Shell.php
+++ b/src/Shell.php
@@ -830,10 +830,8 @@ class Shell extends Application
 
     /**
      * Load user-defined includes.
-     *
-     * The shell output must be configured before include failures can be reported.
      */
-    public function loadIncludes(): void
+    private function loadIncludes()
     {
         // Load user-defined includes
         $load = function (self $__psysh__) {

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -830,20 +830,25 @@ class Shell extends Application
 
     /**
      * Load user-defined includes.
+     *
+     * The shell output must be configured before include failures can be reported.
      */
-    private function loadIncludes()
+    public function loadIncludes(): void
     {
         // Load user-defined includes
         $load = function (self $__psysh__) {
             \set_error_handler([$__psysh__, 'handleError']);
-            foreach ($__psysh__->getIncludes() as $__psysh_include__) {
-                try {
-                    include_once $__psysh_include__;
-                } catch (\Exception $_e) {
-                    $__psysh__->writeException($_e);
+            try {
+                foreach ($__psysh__->getIncludes() as $__psysh_include__) {
+                    try {
+                        include_once $__psysh_include__;
+                    } catch (\Throwable $_e) {
+                        $__psysh__->writeException($_e);
+                    }
                 }
+            } finally {
+                \restore_error_handler();
             }
-            \restore_error_handler();
             unset($__psysh_include__);
 
             // Override any new local variables with pre-defined scope variables

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -91,7 +91,7 @@ class ShellTest extends TestCase
         $this->fail();
     }
 
-    public function testLoadIncludesWithScopeVariables()
+    public function testIncludesWithScopeVariables()
     {
         $include = TempPaths::file('psysh-test-include-');
         \file_put_contents($include, '<?php $one = "clobbered"; $fresh = "from include";');
@@ -103,10 +103,15 @@ class ShellTest extends TestCase
         $_ = 'ignore this';
         $_e = 'ignore this';
 
-        $shell = new Shell($this->getConfig());
+        $config = $this->getConfig([
+            'usePcntl'        => false,
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $shell = new Shell($config);
         $shell->setScopeVariables(\compact('one', 'two', 'three', '__psysh__', '_', '_e', 'this'));
         $shell->setIncludes([$include]);
-        $shell->loadIncludes();
+        $shell->addInput('exit', true);
+        $shell->run(null, $this->getOutput());
 
         $this->assertNotContains('__psysh__', $shell->getScopeVariableNames());
         $this->assertArrayEquals(['one', 'two', 'three', 'fresh', '_'], $shell->getScopeVariableNames());
@@ -117,14 +122,18 @@ class ShellTest extends TestCase
         $this->assertNull($shell->getScopeVariable('_'));
     }
 
-    public function testLoadIncludesContinuesAfterThrowable()
+    public function testIncludesContinueAfterThrowable()
     {
         $invalid = TempPaths::file('psysh-test-include-');
         $valid = TempPaths::file('psysh-test-include-');
         \file_put_contents($invalid, '<?php this is not valid PHP;');
         \file_put_contents($valid, '<?php $included = true;');
 
-        $shell = new class($this->getConfig()) extends Shell {
+        $config = $this->getConfig([
+            'usePcntl'        => false,
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $shell = new class($config) extends Shell {
             public array $exceptions = [];
 
             public function writeException(\Throwable $e)
@@ -133,21 +142,7 @@ class ShellTest extends TestCase
             }
         };
         $shell->setIncludes([$invalid, $valid]);
-        $shell->loadIncludes();
-
-        $this->assertCount(1, $shell->exceptions);
-        $this->assertInstanceOf(\ParseError::class, $shell->exceptions[0]);
-        $this->assertTrue($shell->getScopeVariable('included'));
-    }
-
-    public function testLoadIncludesRestoresErrorHandlerAfterFailure()
-    {
-        $shell = new class($this->getConfig()) extends Shell {
-            public function getIncludes(): array
-            {
-                throw new \RuntimeException('Unable to load includes');
-            }
-        };
+        $shell->addInput('exit', true);
 
         $handler = static function () {
             return true;
@@ -155,12 +150,7 @@ class ShellTest extends TestCase
         \set_error_handler($handler);
 
         try {
-            $exception = null;
-            try {
-                $shell->loadIncludes();
-            } catch (\Throwable $e) {
-                $exception = $e;
-            }
+            $status = $shell->run(null, $this->getOutput());
 
             $currentHandler = \set_error_handler(static function () {
                 return true;
@@ -173,8 +163,58 @@ class ShellTest extends TestCase
                 \restore_error_handler();
             }
 
-            $this->assertInstanceOf(\RuntimeException::class, $exception);
-            $this->assertSame('Unable to load includes', $exception->getMessage());
+            $this->assertSame(0, $status);
+            $this->assertCount(1, $shell->exceptions);
+            $this->assertInstanceOf(\ParseError::class, $shell->exceptions[0]);
+            $this->assertTrue($shell->getScopeVariable('included'));
+            $this->assertSame($handler, $currentHandler);
+        } finally {
+            \restore_error_handler();
+        }
+    }
+
+    public function testIncludesRestoreErrorHandlerAfterFailure()
+    {
+        $config = $this->getConfig([
+            'usePcntl'        => false,
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $shell = new class($config) extends Shell {
+            public array $exceptions = [];
+
+            public function getIncludes(): array
+            {
+                throw new \RuntimeException('Unable to load includes');
+            }
+
+            public function writeException(\Throwable $e)
+            {
+                $this->exceptions[] = $e;
+            }
+        };
+
+        $handler = static function () {
+            return true;
+        };
+        \set_error_handler($handler);
+
+        try {
+            $status = $shell->run(null, $this->getOutput());
+
+            $currentHandler = \set_error_handler(static function () {
+                return true;
+            });
+            \restore_error_handler();
+
+            if ($currentHandler !== $handler) {
+                // A regression leaves an extra frame on the handler stack; drop it so this
+                // test's own cleanup still lands where it started.
+                \restore_error_handler();
+            }
+
+            $this->assertSame(1, $status);
+            $this->assertCount(1, $shell->exceptions);
+            $this->assertInstanceOf(\RuntimeException::class, $shell->exceptions[0]);
             $this->assertSame($handler, $currentHandler);
         } finally {
             \restore_error_handler();

--- a/test/ShellTest.php
+++ b/test/ShellTest.php
@@ -91,8 +91,11 @@ class ShellTest extends TestCase
         $this->fail();
     }
 
-    public function testIncludesWithScopeVariables()
+    public function testLoadIncludesWithScopeVariables()
     {
+        $include = TempPaths::file('psysh-test-include-');
+        \file_put_contents($include, '<?php $one = "clobbered"; $fresh = "from include";');
+
         $one = 'banana';
         $two = 123;
         $three = new \stdClass();
@@ -100,21 +103,82 @@ class ShellTest extends TestCase
         $_ = 'ignore this';
         $_e = 'ignore this';
 
-        $config = $this->getConfig(['usePcntl' => false]);
-
-        $shell = new Shell($config);
+        $shell = new Shell($this->getConfig());
         $shell->setScopeVariables(\compact('one', 'two', 'three', '__psysh__', '_', '_e', 'this'));
-        $shell->addInput('exit', true);
-
-        // This is super slow and we shouldn't do this :(
-        $shell->run(null, $this->getOutput());
+        $shell->setIncludes([$include]);
+        $shell->loadIncludes();
 
         $this->assertNotContains('__psysh__', $shell->getScopeVariableNames());
-        $this->assertArrayEquals(['one', 'two', 'three', '_'], $shell->getScopeVariableNames());
+        $this->assertArrayEquals(['one', 'two', 'three', 'fresh', '_'], $shell->getScopeVariableNames());
         $this->assertSame('banana', $shell->getScopeVariable('one'));
         $this->assertSame(123, $shell->getScopeVariable('two'));
         $this->assertSame($three, $shell->getScopeVariable('three'));
+        $this->assertSame('from include', $shell->getScopeVariable('fresh'));
         $this->assertNull($shell->getScopeVariable('_'));
+    }
+
+    public function testLoadIncludesContinuesAfterThrowable()
+    {
+        $invalid = TempPaths::file('psysh-test-include-');
+        $valid = TempPaths::file('psysh-test-include-');
+        \file_put_contents($invalid, '<?php this is not valid PHP;');
+        \file_put_contents($valid, '<?php $included = true;');
+
+        $shell = new class($this->getConfig()) extends Shell {
+            public array $exceptions = [];
+
+            public function writeException(\Throwable $e)
+            {
+                $this->exceptions[] = $e;
+            }
+        };
+        $shell->setIncludes([$invalid, $valid]);
+        $shell->loadIncludes();
+
+        $this->assertCount(1, $shell->exceptions);
+        $this->assertInstanceOf(\ParseError::class, $shell->exceptions[0]);
+        $this->assertTrue($shell->getScopeVariable('included'));
+    }
+
+    public function testLoadIncludesRestoresErrorHandlerAfterFailure()
+    {
+        $shell = new class($this->getConfig()) extends Shell {
+            public function getIncludes(): array
+            {
+                throw new \RuntimeException('Unable to load includes');
+            }
+        };
+
+        $handler = static function () {
+            return true;
+        };
+        \set_error_handler($handler);
+
+        try {
+            $exception = null;
+            try {
+                $shell->loadIncludes();
+            } catch (\Throwable $e) {
+                $exception = $e;
+            }
+
+            $currentHandler = \set_error_handler(static function () {
+                return true;
+            });
+            \restore_error_handler();
+
+            if ($currentHandler !== $handler) {
+                // A regression leaves an extra frame on the handler stack; drop it so this
+                // test's own cleanup still lands where it started.
+                \restore_error_handler();
+            }
+
+            $this->assertInstanceOf(\RuntimeException::class, $exception);
+            $this->assertSame('Unable to load includes', $exception->getMessage());
+            $this->assertSame($handler, $currentHandler);
+        } finally {
+            \restore_error_handler();
+        }
     }
 
     protected function assertArrayEquals(array $expected, array $actual, $message = '')


### PR DESCRIPTION
PsySH currently stops loading configured include files when one of them has a parse error. Later includes never run, and a failure while loading or reporting can leave PsySH's temporary error handler active.

This change reports PHP errors as well as exceptions, continues loading the remaining files, and always restores the previous error handler.

`include_once` and scope behavior are unchanged. Tests cover parse errors, continued loading, scope precedence, and error-handler cleanup.