### PR TITLE
Restore signal state after shell execution

### DIFF
--- a/src/ExecutionClosure.php
+++ b/src/ExecutionClosure.php
@@ -27,37 +27,44 @@ class ExecutionClosure
     {
         $this->setClosure($__psysh__, function () use ($__psysh__) {
             try {
-                // Restore execution scope variables
-                // @phan-suppress-next-line PhanTypeNonVarPassByRef assigning to a temp variable pollutes scope
-                \extract($__psysh__->getScopeVariables(false));
+                try {
+                    // Restore execution scope variables
+                    // @phan-suppress-next-line PhanTypeNonVarPassByRef assigning to a temp variable pollutes scope
+                    \extract($__psysh__->getScopeVariables(false));
 
-                // Buffer stdout; we'll need it later
-                \ob_start([$__psysh__, 'writeStdout'], 1);
+                    // Buffer stdout; we'll need it later
+                    \ob_start([$__psysh__, 'writeStdout'], 1);
 
-                // Convert all errors to exceptions
-                \set_error_handler([$__psysh__, 'handleError']);
+                    // Convert all errors to exceptions
+                    \set_error_handler([$__psysh__, 'handleError']);
 
-                // Evaluate the current code buffer
-                $_ = eval($__psysh__->onExecute($__psysh__->flushCode() ?: self::NOOP_INPUT));
-            } catch (\Throwable $_e) {
-                // Clean up on our way out.
-                if (\ob_get_level() > 0) {
-                    \ob_end_clean();
+                    // Evaluate the current code buffer
+                    $_ = eval($__psysh__->onExecute($__psysh__->flushCode() ?: self::NOOP_INPUT));
+                } catch (\Throwable $_e) {
+                    // Clean up on our way out.
+                    if (\ob_get_level() > 0) {
+                        \ob_end_clean();
+                    }
+
+                    throw $_e;
+                } finally {
+                    // Won't be needing this anymore
+                    \restore_error_handler();
                 }
 
-                throw $_e;
+                // Flush stdout (write to shell output, plus save to magic variable)
+                \ob_end_flush();
+
+                // Save execution scope variables for next time
+                $__psysh__->setScopeVariables(\get_defined_vars());
+
+                return $_;
             } finally {
-                // Won't be needing this anymore
-                \restore_error_handler();
+                // Full shell runs settle listeners at their outer loop boundary.
+                if (!$__psysh__->isRunActive()) {
+                    $__psysh__->afterLoop();
+                }
             }
-
-            // Flush stdout (write to shell output, plus save to magic variable)
-            \ob_end_flush();
-
-            // Save execution scope variables for next time
-            $__psysh__->setScopeVariables(\get_defined_vars());
-
-            return $_;
         });
     }
 

--- a/src/ExecutionClosure.php
+++ b/src/ExecutionClosure.php
@@ -60,10 +60,7 @@ class ExecutionClosure
 
                 return $_;
             } finally {
-                // Full shell runs settle listeners at their outer loop boundary.
-                if (!$__psysh__->isRunActive()) {
-                    $__psysh__->afterLoop();
-                }
+                $__psysh__->afterLoop();
             }
         });
     }

--- a/src/ExecutionClosure.php
+++ b/src/ExecutionClosure.php
@@ -60,7 +60,7 @@ class ExecutionClosure
 
                 return $_;
             } finally {
-                $__psysh__->afterLoop();
+                $__psysh__->afterExecute();
             }
         });
     }

--- a/src/ExecutionLoop/AbstractListener.php
+++ b/src/ExecutionLoop/AbstractListener.php
@@ -51,6 +51,13 @@ abstract class AbstractListener implements Listener
     /**
      * {@inheritdoc}
      */
+    public function afterExecute(Shell $shell)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function afterLoop(Shell $shell)
     {
     }

--- a/src/ExecutionLoop/Listener.php
+++ b/src/ExecutionLoop/Listener.php
@@ -66,6 +66,13 @@ interface Listener
     public function onExecute(Shell $shell, string $code);
 
     /**
+     * Called after executing user code, even if execution throws.
+     *
+     * @param Shell $shell
+     */
+    public function afterExecute(Shell $shell);
+
+    /**
      * Called at the end of each loop.
      *
      * @param Shell $shell

--- a/src/ExecutionLoop/SignalHandler.php
+++ b/src/ExecutionLoop/SignalHandler.php
@@ -20,6 +20,7 @@ use Psy\Util\DependencyChecker;
  */
 class SignalHandler extends AbstractListener
 {
+    private int $executionDepth = 0;
     private bool $sigintHandlerInstalled = false;
     private bool $restoreStty = false;
     private bool $wasInterrupted = false;
@@ -63,9 +64,10 @@ class SignalHandler extends AbstractListener
     public function onExecute(Shell $shell, string $code)
     {
         $this->wasInterrupted = false;
+        $this->executionDepth++;
 
-        // Nested executions share the signal state owned by their outer loop.
-        if ($this->originalAsyncSignals === null) {
+        // Nested executions share the signal state owned by their outer execution.
+        if ($this->executionDepth === 1) {
             $this->originalSigintHandler = \pcntl_signal_get_handler(\SIGINT);
             $this->originalAsyncSignals = \pcntl_async_signals();
 
@@ -89,12 +91,18 @@ class SignalHandler extends AbstractListener
     }
 
     /**
-     * Called at the end of each loop.
+     * Restore signal state after executing user code.
      *
      * Restores terminal state and clears stdin if execution was interrupted.
      */
-    public function afterLoop(Shell $shell)
+    public function afterExecute(Shell $shell)
     {
+        $this->executionDepth--;
+
+        if ($this->executionDepth > 0) {
+            return;
+        }
+
         // Restore the SIGINT handler and async mode from before execution
         if ($this->sigintHandlerInstalled) {
             \pcntl_signal(\SIGINT, $this->originalSigintHandler);

--- a/src/ExecutionLoop/SignalHandler.php
+++ b/src/ExecutionLoop/SignalHandler.php
@@ -24,9 +24,13 @@ class SignalHandler extends AbstractListener
     private bool $restoreStty = false;
     private bool $wasInterrupted = false;
     private ?string $originalStty = null;
+    /** @var callable|int|null */
+    private $originalSigintHandler;
+    private ?bool $originalAsyncSignals = null;
 
     public const PCNTL_FUNCTIONS = [
         'pcntl_signal',
+        'pcntl_signal_get_handler',
         'pcntl_async_signals',
     ];
 
@@ -60,20 +64,26 @@ class SignalHandler extends AbstractListener
     {
         $this->wasInterrupted = false;
 
-        // Ensure signal processing is enabled so Ctrl-C can interrupt execution
-        if (@\posix_isatty(\STDIN)) {
-            @\shell_exec('stty isig 2>/dev/null');
-            $this->restoreStty = true;
+        // Nested executions share the signal state owned by their outer loop.
+        if ($this->originalAsyncSignals === null) {
+            $this->originalSigintHandler = \pcntl_signal_get_handler(\SIGINT);
+            $this->originalAsyncSignals = \pcntl_async_signals();
+
+            // Ensure signal processing is enabled so Ctrl-C can interrupt execution
+            if ($shell->isRunActive() && @\posix_isatty(\STDIN)) {
+                @\shell_exec('stty isig 2>/dev/null');
+                $this->restoreStty = true;
+            }
+
+            \pcntl_async_signals(true);
+
+            // Install SIGINT handler that throws exception during execution
+            $interrupted = &$this->wasInterrupted;
+            $this->sigintHandlerInstalled = \pcntl_signal(\SIGINT, function () use (&$interrupted) {
+                $interrupted = true;
+                throw new InterruptException('Ctrl+C');
+            });
         }
-
-        \pcntl_async_signals(true);
-
-        // Install SIGINT handler that throws exception during execution
-        $interrupted = &$this->wasInterrupted;
-        $this->sigintHandlerInstalled = \pcntl_signal(\SIGINT, function () use (&$interrupted) {
-            $interrupted = true;
-            throw new InterruptException('Ctrl+C');
-        });
 
         return null;
     }
@@ -85,10 +95,16 @@ class SignalHandler extends AbstractListener
      */
     public function afterLoop(Shell $shell)
     {
-        // Restore default SIGINT handler after execution
+        // Restore the SIGINT handler and async mode from before execution
         if ($this->sigintHandlerInstalled) {
-            \pcntl_signal(\SIGINT, \SIG_DFL);
+            \pcntl_signal(\SIGINT, $this->originalSigintHandler);
             $this->sigintHandlerInstalled = false;
+        }
+        $this->originalSigintHandler = null;
+
+        if ($this->originalAsyncSignals !== null) {
+            \pcntl_async_signals($this->originalAsyncSignals);
+            $this->originalAsyncSignals = null;
         }
 
         // Restore terminal to raw mode after execution

--- a/src/ExecutionLoopClosure.php
+++ b/src/ExecutionLoopClosure.php
@@ -39,39 +39,43 @@ class ExecutionLoopClosure extends ExecutionClosure
                     $__psysh__->getInput();
 
                     try {
-                        // Pull in any new execution scope variables
-                        if ($__psysh__->getLastExecSuccess()) {
-                            // @phan-suppress-next-line PhanTypeNonVarPassByRef assigning to a temp variable pollutes scope
-                            \extract($__psysh__->getScopeVariablesDiff(\get_defined_vars()));
+                        try {
+                            // Pull in any new execution scope variables
+                            if ($__psysh__->getLastExecSuccess()) {
+                                // @phan-suppress-next-line PhanTypeNonVarPassByRef assigning to a temp variable pollutes scope
+                                \extract($__psysh__->getScopeVariablesDiff(\get_defined_vars()));
+                            }
+
+                            // Buffer stdout; we'll need it later
+                            \ob_start([$__psysh__, 'writeStdout'], 1);
+
+                            // Convert all errors to exceptions
+                            \set_error_handler([$__psysh__, 'handleError']);
+
+                            // Evaluate the current code buffer
+                            $_ = eval($__psysh__->onExecute($__psysh__->flushCode() ?: ExecutionClosure::NOOP_INPUT));
+                        } catch (\Throwable $_e) {
+                            // Clean up on our way out.
+                            if (\ob_get_level() > 0) {
+                                \ob_end_clean();
+                            }
+
+                            throw $_e;
+                        } finally {
+                            // Won't be needing this anymore
+                            \restore_error_handler();
                         }
 
-                        // Buffer stdout; we'll need it later
-                        \ob_start([$__psysh__, 'writeStdout'], 1);
+                        // Flush stdout (write to shell output, plus save to magic variable)
+                        \ob_end_flush();
 
-                        // Convert all errors to exceptions
-                        \set_error_handler([$__psysh__, 'handleError']);
+                        // Save execution scope variables for next time
+                        $__psysh__->setScopeVariables(\get_defined_vars());
 
-                        // Evaluate the current code buffer
-                        $_ = eval($__psysh__->onExecute($__psysh__->flushCode() ?: ExecutionClosure::NOOP_INPUT));
-                    } catch (\Throwable $_e) {
-                        // Clean up on our way out.
-                        if (\ob_get_level() > 0) {
-                            \ob_end_clean();
-                        }
-
-                        throw $_e;
+                        $__psysh__->writeReturnValue($_);
                     } finally {
-                        // Won't be needing this anymore
-                        \restore_error_handler();
+                        $__psysh__->afterExecute();
                     }
-
-                    // Flush stdout (write to shell output, plus save to magic variable)
-                    \ob_end_flush();
-
-                    // Save execution scope variables for next time
-                    $__psysh__->setScopeVariables(\get_defined_vars());
-
-                    $__psysh__->writeReturnValue($_);
                 } catch (BreakException $_e) {
                     // exit() or ctrl-d exits the REPL
                     $__psysh__->writeException($_e);

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -1037,10 +1037,14 @@ class Shell extends Application
     }
 
     /**
-     * Run execution loop listeners after each loop.
+     * Run execution loop listeners after the outermost execution.
      */
     public function afterLoop()
     {
+        if ($this->executionDepth > 1) {
+            return;
+        }
+
         $this->disableInteractiveSignalCharsIfNeeded();
 
         foreach (\array_reverse($this->loopListeners) as $listener) {

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -97,7 +97,7 @@ class Shell extends Application
     private bool $lastExecSuccess = true;
     private bool $suppressReturnValue = false;
     private bool $nonInteractive = false;
-    private bool $runActive = false;
+    private int $runDepth = 0;
     private int $executionDepth = 0;
     private ?int $errorReporting = null;
     private bool $interactiveSignalCharsEnabled = false;
@@ -711,7 +711,7 @@ class Shell extends Application
         $this->clearPendingCode();
         $this->warmAutoloader();
 
-        $this->runActive = true;
+        $this->runDepth++;
 
         // Treat the whole run as one execution, so nested execute() calls don't reload includes.
         $this->executionDepth++;
@@ -725,7 +725,7 @@ class Shell extends Application
             }
         } finally {
             $this->executionDepth--;
-            $this->runActive = false;
+            $this->runDepth--;
         }
     }
 
@@ -734,7 +734,7 @@ class Shell extends Application
      */
     public function isRunActive(): bool
     {
-        return $this->runActive;
+        return $this->runDepth > 0;
     }
 
     /**
@@ -811,21 +811,17 @@ class Shell extends Application
             $this->loadIncludes();
         }
 
-        try {
-            try {
-                // For non-interactive execution, read only from the input buffer or from piped input.
-                // Otherwise it'll try to readline and hang, waiting for user input with no indication of
-                // what's holding things up.
-                if (!empty($this->inputBuffer) || $this->config->inputIsPiped()) {
-                    $this->getInput(false);
-                }
+        // For non-interactive execution, read only from the input buffer or from piped input.
+        // Otherwise it'll try to readline and hang, waiting for user input with no indication of
+        // what's holding things up.
+        if (!empty($this->inputBuffer) || $this->config->inputIsPiped()) {
+            $this->getInput(false);
+        }
 
-                if ($this->hasCode()) {
-                    $ret = $this->execute($this->flushCode());
-                    $this->writeReturnValue($ret, $rawOutput);
-                }
-            } finally {
-                $this->afterLoop();
+        try {
+            if ($this->hasCode()) {
+                $ret = $this->execute($this->flushCode());
+                $this->writeReturnValue($ret, $rawOutput);
             }
         } catch (BreakException $e) {
             // User called exit() in non-interactive mode
@@ -1037,14 +1033,20 @@ class Shell extends Application
     }
 
     /**
-     * Run execution loop listeners after the outermost execution.
+     * Run execution loop listeners after executing user code.
+     */
+    public function afterExecute()
+    {
+        foreach (\array_reverse($this->loopListeners) as $listener) {
+            $listener->afterExecute($this);
+        }
+    }
+
+    /**
+     * Run execution loop listeners after each loop.
      */
     public function afterLoop()
     {
-        if ($this->executionDepth > 1) {
-            return;
-        }
-
         $this->disableInteractiveSignalCharsIfNeeded();
 
         foreach (\array_reverse($this->loopListeners) as $listener) {
@@ -1175,7 +1177,7 @@ class Shell extends Application
     private function enableInteractiveSignalCharsIfNeeded(): void
     {
         if (
-            !$this->runActive
+            $this->runDepth < 1
             || $this->interactiveSignalCharsEnabled
             || $this->nonInteractive
             || !($this->readline instanceof InteractiveReadlineInterface)

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -97,6 +97,7 @@ class Shell extends Application
     private bool $lastExecSuccess = true;
     private bool $suppressReturnValue = false;
     private bool $nonInteractive = false;
+    private bool $runActive = false;
     private ?int $errorReporting = null;
     private bool $interactiveSignalCharsEnabled = false;
     private bool $outputWritten = false;
@@ -709,12 +710,26 @@ class Shell extends Application
         $this->clearPendingCode();
         $this->warmAutoloader();
 
-        if ($this->config->getInputInteractive()) {
-            // @todo should it be possible to have raw output in an interactive run?
-            return $this->doInteractiveRun();
-        } else {
-            return $this->doNonInteractiveRun($this->config->rawOutput());
+        $this->runActive = true;
+
+        try {
+            if ($this->config->getInputInteractive()) {
+                // @todo should it be possible to have raw output in an interactive run?
+                return $this->doInteractiveRun();
+            } else {
+                return $this->doNonInteractiveRun($this->config->rawOutput());
+            }
+        } finally {
+            $this->runActive = false;
         }
+    }
+
+    /**
+     * Check whether a full shell run is active.
+     */
+    public function isRunActive(): bool
+    {
+        return $this->runActive;
     }
 
     /**
@@ -787,17 +802,21 @@ class Shell extends Application
         $this->beforeRun();
         $this->loadIncludes();
 
-        // For non-interactive execution, read only from the input buffer or from piped input.
-        // Otherwise it'll try to readline and hang, waiting for user input with no indication of
-        // what's holding things up.
-        if (!empty($this->inputBuffer) || $this->config->inputIsPiped()) {
-            $this->getInput(false);
-        }
-
         try {
-            if ($this->hasCode()) {
-                $ret = $this->execute($this->flushCode());
-                $this->writeReturnValue($ret, $rawOutput);
+            try {
+                // For non-interactive execution, read only from the input buffer or from piped input.
+                // Otherwise it'll try to readline and hang, waiting for user input with no indication of
+                // what's holding things up.
+                if (!empty($this->inputBuffer) || $this->config->inputIsPiped()) {
+                    $this->getInput(false);
+                }
+
+                if ($this->hasCode()) {
+                    $ret = $this->execute($this->flushCode());
+                    $this->writeReturnValue($ret, $rawOutput);
+                }
+            } finally {
+                $this->afterLoop();
             }
         } catch (BreakException $e) {
             // User called exit() in non-interactive mode
@@ -1138,7 +1157,8 @@ class Shell extends Application
     private function enableInteractiveSignalCharsIfNeeded(): void
     {
         if (
-            $this->interactiveSignalCharsEnabled
+            !$this->runActive
+            || $this->interactiveSignalCharsEnabled
             || $this->nonInteractive
             || !($this->readline instanceof InteractiveReadlineInterface)
             || $this->hasSigintExecutionListener()

--- a/test/ExecutionClosureTest.php
+++ b/test/ExecutionClosureTest.php
@@ -12,6 +12,7 @@
 namespace Psy\Test;
 
 use Psy\Configuration;
+use Psy\ExecutionLoopClosure;
 use Psy\ExecutionLoop\AbstractListener;
 use Psy\Shell;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -28,18 +29,19 @@ class ExecutionClosureTest extends TestCase
         parent::tearDown();
     }
 
-    public function testAfterLoopRunsAfterSuccessfulExecutionIsSettled()
+    public function testAfterExecuteRunsAfterSuccessfulExecutionIsSettled()
     {
         [$shell, $listener] = $this->getShell();
 
         $this->assertSame(42, $shell->execute('echo "hello"; $answer = 42; $answer', true));
-        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame(1, $listener->afterExecuteCalls);
+        $this->assertSame(0, $listener->afterLoopCalls);
         $this->assertSame(42, $listener->scopeVariables['answer']);
         $this->assertSame('hello', $listener->scopeVariables['__out']);
         $this->assertSame([false, false], $listener->runActiveStates);
     }
 
-    public function testAfterLoopRunsAfterFailedExecutionIsCleanedUp()
+    public function testAfterExecuteRunsAfterFailedExecutionIsCleanedUp()
     {
         [$shell, $listener] = $this->getShell();
         $outputBufferLevel = \ob_get_level();
@@ -51,19 +53,36 @@ class ExecutionClosureTest extends TestCase
             $this->assertSame('failed', $e->getMessage());
         }
 
-        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame(1, $listener->afterExecuteCalls);
+        $this->assertSame(0, $listener->afterLoopCalls);
         $this->assertSame($outputBufferLevel, $listener->outputBufferLevel);
         $this->assertSame([false, false], $listener->runActiveStates);
     }
 
-    public function testNestedDirectExecutionSettlesListenersOnce()
+    public function testNestedDirectExecutionPairsExecutionCallbacks()
     {
         [$shell, $listener] = $this->getShell();
         $shell->setScopeVariables(['shell' => $shell]);
 
         $this->assertSame([1, 2], $shell->execute('return [1, $shell->execute("return 2;", true)];', true));
         $this->assertSame(2, $listener->onExecuteCalls);
-        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame(2, $listener->afterExecuteCalls);
+        $this->assertSame(0, $listener->afterLoopCalls);
+    }
+
+    public function testExecutionLoopPairsExecutionCallbacksWithoutChangingLoopCallbacks()
+    {
+        [$shell, $listener] = $this->getShell();
+        $shell->addInput('42', true);
+        $shell->addInput('exit', true);
+
+        $loop = new ExecutionLoopClosure($shell);
+
+        $this->assertSame(0, $loop->execute());
+        $this->assertSame(1, $listener->onExecuteCalls);
+        $this->assertSame(1, $listener->afterExecuteCalls);
+        $this->assertSame(2, $listener->afterLoopCalls);
+        $this->assertSame(42, $listener->scopeVariables['_']);
     }
 
     public function testFullRunOwnsRunStateForItsCompleteLifecycle()
@@ -78,17 +97,31 @@ class ExecutionClosureTest extends TestCase
         $this->assertFalse($shell->isRunActive());
     }
 
-    public function testFullRunSettlesNestedExecutionsOnce()
+    public function testFullRunPairsNestedExecutionCallbacksWithoutLoopCallbacks()
     {
         [$shell, $listener] = $this->getShell([
             'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
         ]);
         $shell->addInput('timeit -n3 1 + 1', true);
-        $shell->addInput('exit', true);
 
         $this->assertSame(0, $shell->doRun(new ArrayInput([]), new BufferedOutput()));
         $this->assertSame(3, $listener->onExecuteCalls);
-        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame(3, $listener->afterExecuteCalls);
+        $this->assertSame(0, $listener->afterLoopCalls);
+    }
+
+    public function testNestedFullRunKeepsOuterRunActive()
+    {
+        [$shell] = $this->getShell([
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $output = new BufferedOutput();
+        $shell->setScopeVariables(['shell' => $shell, 'output' => $output]);
+        $shell->addInput('[$shell->run(null, $output), $shell->isRunActive()]', true);
+
+        $this->assertSame(0, $shell->doRun(new ArrayInput([]), $output));
+        $this->assertSame([0, true], $shell->getScopeVariable('_'));
+        $this->assertFalse($shell->isRunActive());
     }
 
     public function testFullRunReleasesRunStateAfterFailure()
@@ -131,6 +164,7 @@ class ExecutionClosureTest extends TestCase
 
 class ExecutionClosureListener extends AbstractListener
 {
+    public int $afterExecuteCalls = 0;
     public int $afterLoopCalls = 0;
     public bool $failBeforeRun = false;
     public int $onExecuteCalls = 0;
@@ -160,11 +194,17 @@ class ExecutionClosureListener extends AbstractListener
         return null;
     }
 
+    public function afterExecute(Shell $shell)
+    {
+        $this->afterExecuteCalls++;
+        $this->outputBufferLevel = \ob_get_level();
+        $this->scopeVariables = $shell->getScopeVariables();
+        $this->runActiveStates[] = $shell->isRunActive();
+    }
+
     public function afterLoop(Shell $shell)
     {
         $this->afterLoopCalls++;
-        $this->outputBufferLevel = \ob_get_level();
-        $this->scopeVariables = $shell->getScopeVariables();
         $this->runActiveStates[] = $shell->isRunActive();
     }
 

--- a/test/ExecutionClosureTest.php
+++ b/test/ExecutionClosureTest.php
@@ -56,6 +56,16 @@ class ExecutionClosureTest extends TestCase
         $this->assertSame([false, false], $listener->runActiveStates);
     }
 
+    public function testNestedDirectExecutionSettlesListenersOnce()
+    {
+        [$shell, $listener] = $this->getShell();
+        $shell->setScopeVariables(['shell' => $shell]);
+
+        $this->assertSame([1, 2], $shell->execute('return [1, $shell->execute("return 2;", true)];', true));
+        $this->assertSame(2, $listener->onExecuteCalls);
+        $this->assertSame(1, $listener->afterLoopCalls);
+    }
+
     public function testFullRunOwnsRunStateForItsCompleteLifecycle()
     {
         [$shell, $listener] = $this->getShell([

--- a/test/ExecutionClosureTest.php
+++ b/test/ExecutionClosureTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2026 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test;
+
+use Psy\Configuration;
+use Psy\ExecutionLoop\AbstractListener;
+use Psy\Shell;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ExecutionClosureTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        if (\function_exists('readline_clear_history')) {
+            \readline_clear_history();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testAfterLoopRunsAfterSuccessfulExecutionIsSettled()
+    {
+        [$shell, $listener] = $this->getShell();
+
+        $this->assertSame(42, $shell->execute('echo "hello"; $answer = 42; $answer', true));
+        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame(42, $listener->scopeVariables['answer']);
+        $this->assertSame('hello', $listener->scopeVariables['__out']);
+        $this->assertSame([false, false], $listener->runActiveStates);
+    }
+
+    public function testAfterLoopRunsAfterFailedExecutionIsCleanedUp()
+    {
+        [$shell, $listener] = $this->getShell();
+        $outputBufferLevel = \ob_get_level();
+
+        try {
+            $shell->execute('throw new \RuntimeException("failed")', true);
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('failed', $e->getMessage());
+        }
+
+        $this->assertSame(1, $listener->afterLoopCalls);
+        $this->assertSame($outputBufferLevel, $listener->outputBufferLevel);
+        $this->assertSame([false, false], $listener->runActiveStates);
+    }
+
+    public function testFullRunOwnsRunStateForItsCompleteLifecycle()
+    {
+        [$shell, $listener] = $this->getShell([
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $shell->addInput('21 * 2', true);
+
+        $this->assertSame(0, $shell->doRun(new ArrayInput([]), new BufferedOutput()));
+        $this->assertSame([true, true, true, true], $listener->runActiveStates);
+        $this->assertFalse($shell->isRunActive());
+    }
+
+    public function testFullRunSettlesNestedExecutionsOnce()
+    {
+        [$shell, $listener] = $this->getShell([
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $shell->addInput('timeit -n3 1 + 1', true);
+        $shell->addInput('exit', true);
+
+        $this->assertSame(0, $shell->doRun(new ArrayInput([]), new BufferedOutput()));
+        $this->assertSame(3, $listener->onExecuteCalls);
+        $this->assertSame(1, $listener->afterLoopCalls);
+    }
+
+    public function testFullRunReleasesRunStateAfterFailure()
+    {
+        [$shell, $listener] = $this->getShell([
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $listener->failBeforeRun = true;
+
+        try {
+            $shell->doRun(new ArrayInput([]), new BufferedOutput());
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('failed', $e->getMessage());
+        }
+
+        $this->assertSame([true], $listener->runActiveStates);
+        $this->assertFalse($shell->isRunActive());
+    }
+
+    /**
+     * @return array{Shell, ExecutionClosureListener}
+     */
+    private function getShell(array $options = []): array
+    {
+        $dir = TempPaths::reserve('psysh-test-execution-closure-');
+        $config = new Configuration(\array_merge([
+            'configDir'    => $dir,
+            'dataDir'      => $dir,
+            'runtimeDir'   => $dir,
+            'trustProject' => false,
+        ], $options));
+        $listener = new ExecutionClosureListener();
+        $shell = new ExecutionClosureTestShell($config, $listener);
+        $shell->setOutput(new BufferedOutput());
+
+        return [$shell, $listener];
+    }
+}
+
+class ExecutionClosureListener extends AbstractListener
+{
+    public int $afterLoopCalls = 0;
+    public bool $failBeforeRun = false;
+    public int $onExecuteCalls = 0;
+    public ?int $outputBufferLevel = null;
+    public array $scopeVariables = [];
+    public array $runActiveStates = [];
+
+    public static function isSupported(): bool
+    {
+        return true;
+    }
+
+    public function beforeRun(Shell $shell)
+    {
+        $this->runActiveStates[] = $shell->isRunActive();
+
+        if ($this->failBeforeRun) {
+            throw new \RuntimeException('failed');
+        }
+    }
+
+    public function onExecute(Shell $shell, string $code)
+    {
+        $this->onExecuteCalls++;
+        $this->runActiveStates[] = $shell->isRunActive();
+
+        return null;
+    }
+
+    public function afterLoop(Shell $shell)
+    {
+        $this->afterLoopCalls++;
+        $this->outputBufferLevel = \ob_get_level();
+        $this->scopeVariables = $shell->getScopeVariables();
+        $this->runActiveStates[] = $shell->isRunActive();
+    }
+
+    public function afterRun(Shell $shell, int $exitCode = 0)
+    {
+        $this->runActiveStates[] = $shell->isRunActive();
+    }
+}
+
+class ExecutionClosureTestShell extends Shell
+{
+    private ExecutionClosureListener $listener;
+
+    public function __construct(Configuration $config, ExecutionClosureListener $listener)
+    {
+        $this->listener = $listener;
+
+        parent::__construct($config);
+    }
+
+    protected function getDefaultLoopListeners(): array
+    {
+        return [$this->listener];
+    }
+}

--- a/test/ExecutionClosureTest.php
+++ b/test/ExecutionClosureTest.php
@@ -12,8 +12,8 @@
 namespace Psy\Test;
 
 use Psy\Configuration;
-use Psy\ExecutionLoopClosure;
 use Psy\ExecutionLoop\AbstractListener;
+use Psy\ExecutionLoopClosure;
 use Psy\Shell;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/test/ExecutionLoop/SignalHandlerTest.php
+++ b/test/ExecutionLoop/SignalHandlerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of Psy Shell.
+ *
+ * (c) 2012-2026 Justin Hileman
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Psy\Test\ExecutionLoop;
+
+use Psy\Configuration;
+use Psy\ExecutionLoop\SignalHandler;
+use Psy\Shell;
+use Psy\Test\TempPaths;
+use Psy\Test\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class SignalHandlerTest extends TestCase
+{
+    /** @var callable|int */
+    private $originalSigintHandler;
+    private ?bool $originalAsyncSignals = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!SignalHandler::isSupported()) {
+            $this->markTestSkipped('Signal handling is not supported');
+        }
+
+        $this->originalSigintHandler = \pcntl_signal_get_handler(\SIGINT);
+        $this->originalAsyncSignals = \pcntl_async_signals();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalAsyncSignals !== null) {
+            \pcntl_signal(\SIGINT, $this->originalSigintHandler);
+            \pcntl_async_signals($this->originalAsyncSignals);
+        }
+
+        if (\function_exists('readline_clear_history')) {
+            \readline_clear_history();
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider asyncSignalsModes
+     */
+    public function testDirectExecutionRestoresSignalState(bool $asyncSignals)
+    {
+        $shell = $this->getShell();
+        $handler = static function (): void {
+        };
+        \pcntl_signal(\SIGINT, $handler);
+        \pcntl_async_signals($asyncSignals);
+
+        $this->assertSame(42, $shell->execute('21 * 2', true));
+
+        $this->assertSame($handler, \pcntl_signal_get_handler(\SIGINT));
+        $this->assertSame($asyncSignals, \pcntl_async_signals());
+    }
+
+    /**
+     * @dataProvider asyncSignalsModes
+     */
+    public function testDirectExecutionRestoresSignalStateAfterException(bool $asyncSignals)
+    {
+        $shell = $this->getShell();
+        $handler = static function (): void {
+        };
+        \pcntl_signal(\SIGINT, $handler);
+        \pcntl_async_signals($asyncSignals);
+
+        try {
+            $shell->execute('throw new \RuntimeException("failed")', true);
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('failed', $e->getMessage());
+        }
+
+        $this->assertSame($handler, \pcntl_signal_get_handler(\SIGINT));
+        $this->assertSame($asyncSignals, \pcntl_async_signals());
+    }
+
+    /**
+     * @dataProvider asyncSignalsModes
+     */
+    public function testNonInteractiveRunRestoresSignalState(bool $asyncSignals)
+    {
+        $shell = $this->getShell([
+            'interactiveMode' => Configuration::INTERACTIVE_MODE_DISABLED,
+        ]);
+        $handler = static function (): void {
+        };
+        \pcntl_signal(\SIGINT, $handler);
+        \pcntl_async_signals($asyncSignals);
+        $shell->addInput('timeit -n3 1 + 1', true);
+        $shell->addInput('exit', true);
+
+        $this->assertSame(0, $shell->doRun(new ArrayInput([]), new BufferedOutput()));
+        $this->assertSame($handler, \pcntl_signal_get_handler(\SIGINT));
+        $this->assertSame($asyncSignals, \pcntl_async_signals());
+    }
+
+    public function asyncSignalsModes(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
+    }
+
+    private function getShell(array $options = []): Shell
+    {
+        $dir = TempPaths::reserve('psysh-test-signal-handler-');
+        $config = new Configuration(\array_merge([
+            'configDir'    => $dir,
+            'dataDir'      => $dir,
+            'runtimeDir'   => $dir,
+            'trustProject' => false,
+            'usePcntl'     => false,
+        ], $options));
+
+        $shell = new Shell($config);
+        $shell->setOutput(new BufferedOutput());
+
+        return $shell;
+    }
+}

--- a/test/ExecutionLoop/SignalHandlerTest.php
+++ b/test/ExecutionLoop/SignalHandlerTest.php
@@ -93,6 +93,30 @@ class SignalHandlerTest extends TestCase
     /**
      * @dataProvider asyncSignalsModes
      */
+    public function testNestedDirectExecutionKeepsOuterSignalState(bool $asyncSignals)
+    {
+        $shell = $this->getShell();
+        $handler = static function (): void {
+        };
+        \pcntl_signal(\SIGINT, $handler);
+        \pcntl_async_signals($asyncSignals);
+        $shell->setScopeVariables(['shell' => $shell]);
+
+        $result = $shell->execute(
+            '$installed = \pcntl_signal_get_handler(\SIGINT);'
+            .'$shell->execute("return 2;", true);'
+            .'return [$installed === \pcntl_signal_get_handler(\SIGINT), \pcntl_async_signals()];',
+            true
+        );
+
+        $this->assertSame([true, true], $result);
+        $this->assertSame($handler, \pcntl_signal_get_handler(\SIGINT));
+        $this->assertSame($asyncSignals, \pcntl_async_signals());
+    }
+
+    /**
+     * @dataProvider asyncSignalsModes
+     */
     public function testNonInteractiveRunRestoresSignalState(bool $asyncSignals)
     {
         $shell = $this->getShell([

--- a/test/ExecutionLoop/SignalHandlerTest.php
+++ b/test/ExecutionLoop/SignalHandlerTest.php
@@ -127,7 +127,6 @@ class SignalHandlerTest extends TestCase
         \pcntl_signal(\SIGINT, $handler);
         \pcntl_async_signals($asyncSignals);
         $shell->addInput('timeit -n3 1 + 1', true);
-        $shell->addInput('exit', true);
 
         $this->assertSame(0, $shell->doRun(new ArrayInput([]), new BufferedOutput()));
         $this->assertSame($handler, \pcntl_signal_get_handler(\SIGINT));

--- a/test/smoketest-pty.sh
+++ b/test/smoketest-pty.sh
@@ -13,7 +13,7 @@
 # Integration smoke tests that run PsySH under a PTY (pseudo-terminal) via
 # the Linux util-linux `script` command. These tests verify interactive
 # behavior that requires a real terminal: command execution, pager lifecycle,
-# Composer proxy startup, and project trust flags.
+# Composer proxy startup, project trust flags, and direct execution cleanup.
 #
 # Usage:
 #   test/smoketest-pty.sh                    # Test bin/psysh (default)
@@ -50,9 +50,11 @@ LAST_STATUS=0
 TMP_DIR="$(mktemp -d)"
 readonly TMP_DIR
 readonly CONFIG_FILE="${TMP_DIR}/psysh.php"
+readonly SIGNAL_CONFIG_FILE="${TMP_DIR}/psysh-signal.php"
 readonly PROXY_PROJECT="${TMP_DIR}/proxy-project"
 readonly PAGER_SCRIPT="${TMP_DIR}/pager.sh"
 readonly TRUST_RUNNER="${TMP_DIR}/trust-runner.php"
+readonly SIGNAL_RUNNER="${TMP_DIR}/signal-runner.php"
 
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
@@ -63,6 +65,7 @@ readonly CONFIG_DIR="${XDG_CONFIG_HOME}"
 
 mkdir -p "${CONFIG_DIR}/psysh" "${PROXY_PROJECT}/vendor/bin" "${PROXY_PROJECT}/vendor"
 printf '<?php return [];%s' $'\n' > "${CONFIG_FILE}"
+printf '<?php return ["usePcntl" => false];%s' $'\n' > "${SIGNAL_CONFIG_FILE}"
 printf '<?php%s' $'\n' > "${PROXY_PROJECT}/vendor/autoload.php"
 cat > "${PROXY_PROJECT}/composer.lock" <<'JSON'
 {
@@ -122,6 +125,49 @@ echo json_encode([
 ]);
 PHP
 
+cat > "${SIGNAL_RUNNER}" <<'PHP'
+<?php
+require $argv[1];
+
+use Psy\Configuration;
+use Psy\Shell;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class ShellWithoutLoopListeners extends Shell
+{
+    protected function getDefaultLoopListeners(): array
+    {
+        return [];
+    }
+}
+
+$mode = $argv[2];
+$tempDir = $argv[3];
+$configFile = $argv[4];
+$config = new Configuration([
+    'configDir'               => $tempDir,
+    'configFile'              => $configFile,
+    'dataDir'                 => $tempDir,
+    'runtimeDir'              => $tempDir,
+    'trustProject'            => false,
+    'useExperimentalReadline' => $mode === 'shell',
+    'usePcntl'                => false,
+]);
+$shell = $mode === 'shell'
+    ? new ShellWithoutLoopListeners($config)
+    : new Shell($config);
+$shell->setOutput(new StreamOutput(fopen('php://memory', 'w+')));
+
+$before = trim((string) shell_exec('stty -g 2>/dev/null'));
+$shell->execute('21 * 2', true);
+$after = trim((string) shell_exec('stty -g 2>/dev/null'));
+
+if ($before !== $after) {
+    fwrite(STDERR, "Terminal state changed during direct execution.\n");
+    exit(1);
+}
+PHP
+
 BIN_PATH="$(cd "${ROOT_DIR}" && php -r 'echo realpath($argv[1]);' "${TARGET}")"
 readonly BIN_PATH
 
@@ -169,6 +215,10 @@ fail() {
 
 pass() {
   echo "PASSED"
+}
+
+skip() {
+  echo "SKIPPED ($1)"
 }
 
 assert_status() {
@@ -289,12 +339,46 @@ test_pager_lifecycle() {
     pass
 }
 
+test_direct_execute_terminal_state() {
+  echo -n "  Direct execute signals: "
+
+  if [[ "${TARGET}" != "bin/psysh" ]]; then
+    skip "source-only test"
+    return
+  fi
+
+  run_pty '' \
+    bash -c 'stty isig; exec "$@"' _ \
+    php "${SIGNAL_RUNNER}" "${ROOT_DIR}/vendor/autoload.php" signal-handler "${TMP_DIR}" "${CONFIG_FILE}"
+  assert_status 0 || return 1
+
+  run_pty '' \
+    bash -c 'stty isig; exec "$@"' _ \
+    php "${SIGNAL_RUNNER}" "${ROOT_DIR}/vendor/autoload.php" shell "${TMP_DIR}" "${CONFIG_FILE}"
+  assert_status 0 && pass
+}
+
+test_signal_handler_terminal_state() {
+  echo -n "  Signal handler state:  "
+
+  run_pty $'echo 42;\nexit\n' \
+    bash -c 'stty isig; before=$(stty -g); "$@"; status=$?; after=$(stty -g); [[ "$before" = "$after" ]] || exit 99; exit "$status"' _ \
+    env HOME="${HOME_DIR}" XDG_CONFIG_HOME="${CONFIG_DIR}" TERM=xterm-256color \
+    php "${BIN_PATH}" -c "${SIGNAL_CONFIG_FILE}" --no-pager --no-trust-project
+
+  assert_status 0 &&
+    assert_contains '42' &&
+    pass
+}
+
 echo "PsySH PTY Smoke Tests (${TARGET})"
 test_direct_startup || true
 test_exit_code_path || true
 test_composer_proxy_startup || true
 test_trust_flags || true
 test_pager_lifecycle || true
+test_direct_execute_terminal_state || true
+test_signal_handler_terminal_state || true
 
 if [[ "${FAILED}" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
When code runs through `Shell::execute()`, PsySH sets up Ctrl-C handling like it does in the REPL. That state needs to be restored afterwards, including when user code throws.

This PR adds an `afterExecute()` listener hook paired with `onExecute()`. `SignalHandler` uses it to restore the previous SIGINT handler and async-signal mode. Nested executions share the outer signal state, so only the outer call restores it.

It also tracks nested `run()` calls with a counter so an inner run can’t clear the outer run’s active state. `afterLoop()` stays paired with `beforeLoop()` and keeps its existing loop-only behavior.