### PR TITLE
Resolve a generic docblock type to its container

### DIFF
--- a/src/Completion/TypeResolver.php
+++ b/src/Completion/TypeResolver.php
@@ -850,7 +850,11 @@ class TypeResolver
             return [];
         }
 
-        if (\preg_match('/^[\w\\\\]+<(.+)>$/', $typeString, $matches)) {
+        // A generic names the type of the value itself, not of what it holds:
+        // `Collection<int, User>` is a Collection. Resolving the arguments
+        // instead offers the members of the wrong class, and for more than one
+        // argument produces a type name no class ever has ("int, User").
+        if (\preg_match('/^([\w\\\\]+)<.+>$/', $typeString, $matches)) {
             return $this->parseDocblockTypes($matches[1], $classContext);
         }
 

--- a/test/Completion/TypeResolverTest.php
+++ b/test/Completion/TypeResolverTest.php
@@ -412,6 +412,30 @@ class TypeResolverTest extends TestCase
                 ['Psy\Test\Fixtures\Completion\City'],
             ],
 
+            // Generic docblock return types name the container, not what it
+            // holds: the expression is a Collection, so it is the Collection's
+            // members that can follow it.
+            'generic docblock return type' => [
+                fn ($ctx) => $ctx->setAll(['repo' => new Repository()]),
+                '$repo->all()',
+                ['Psy\Test\Fixtures\Completion\Collection'],
+            ],
+            'generic docblock return type with a non-class container' => [
+                fn ($ctx) => $ctx->setAll(['repo' => new Repository()]),
+                '$repo->page()',
+                [],
+            ],
+            'generic docblock return type continues a chain' => [
+                fn ($ctx) => $ctx->setAll(['repo' => new Repository()]),
+                '$repo->all()->first()',
+                ['Psy\Test\Fixtures\Completion\User'],
+            ],
+            'generic array docblock return type' => [
+                fn ($ctx) => $ctx->setAll(['repo' => new Repository()]),
+                '$repo->keyed()',
+                [],
+            ],
+
             // Docblock return types
             'docblock return type' => [
                 fn ($ctx) => $ctx->setAll(['city' => new City()]),

--- a/test/Fixtures/Completion/Collection.php
+++ b/test/Fixtures/Completion/Collection.php
@@ -11,6 +11,10 @@
 
 namespace Psy\Test\Fixtures\Completion;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
 class Collection
 {
     public function filter(callable $callback): self

--- a/test/Fixtures/Completion/Repository.php
+++ b/test/Fixtures/Completion/Repository.php
@@ -32,4 +32,28 @@ class Repository
     {
         return new User();
     }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function all()
+    {
+        return new Collection();
+    }
+
+    /**
+     * @return iterable<User>
+     */
+    public function page()
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, User>
+     */
+    public function keyed()
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
`@return Collection<int, User>` describes a `Collection`, but `parseDocblockTypes()` resolves the type *arguments* rather than the type itself, so completion offers the members of the wrong class.

```php
if (\preg_match('/^[\w\\\\]+<(.+)>$/', $typeString, $matches)) {
    return $this->parseDocblockTypes($matches[1], $classContext);
}
```

With more than one argument it produces a name no class ever has. The whole argument list is passed on as a single type, so `Collection<int, User>` resolves to a class called `"int, User"`; nothing downstream can reflect on it, and no members are offered at all. That's the common shape in Laravel — `Collection<int, User>`, `Collection<TKey, TValue>` — so on a Laravel model the effect is that a chain simply stops.

It's also the opposite of what the branch two lines above does for `User[]`, which resolves to nothing on the grounds that an array has no members to complete. A `Collection` does have members — they're the Collection's.

Resolving the outer name settles all three cases:

| `@return` | before | after |
| --- | --- | --- |
| `Collection<int, User>` | `"int, User"` | `Collection` |
| `Collection<User>` | `User` | `Collection` |
| `array<string, User>` | `"string, User"` | nothing, matching `User[]` |
| `User[]` | nothing | nothing |

Four cases added to `methodChainingProvider`, including one that chains off the collection (`$repo->all()->first()`) to show the members now resolve. All four fail on `main` and pass with the change; the full suite is green (4792 tests).

I ran into this building browser completion on `CompletionEngine` for [spatie/laravel-web-tinker](https://github.com/spatie/laravel-web-tinker/pull/125) — thanks for the pointer to the engine, it's a much better base than what I had.

One thing I wasn't sure about: if the argument unwrapping is deliberate for some case I haven't found, the alternative would be returning both the container and its last argument. I went with the container alone, since that's what the expression evaluates to and it matches the `[]` branch. Happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeokeyBuZ3JKQYJ5L6gscZ
